### PR TITLE
Brug rich

### DIFF
--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -6,8 +6,12 @@ import sys
 import os
 
 import click
+import rich.traceback
+import sqlalchemy
 
 from fire.api import FireDb
+
+rich.traceback.install(show_locals=True, suppress=[click, sqlalchemy])
 
 firedb = FireDb()
 _show_colors = True

--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -4,6 +4,7 @@ Kommandoliniebrugergrænsefladen (en command-line interface, CLI) til FIREs API.
 """
 import sys
 import os
+import signal
 
 import click
 import rich.traceback
@@ -11,7 +12,17 @@ import sqlalchemy
 
 from fire.api import FireDb
 
+# Pæne tracebacks med relevant debug info. Udelader output fra pakker
+# spytter exceptionelt meget (irrellevant) output ud ved fejl
 rich.traceback.install(show_locals=True, suppress=[click, sqlalchemy])
+
+# Undgå enorme, ubrugelige tracebacks når programmet afbrydes med CTRL+C
+def luk_pænt_ved_ctrl_c(signal, frame):
+    raise SystemExit
+
+
+signal.signal(signal.SIGINT, luk_pænt_ved_ctrl_c)
+
 
 firedb = FireDb()
 _show_colors = True


### PR DESCRIPTION
Bare en lille showcase for @xidus. Stacktraces er meget bedre hvis man kører dem gennem `rich`:

<img width="840" alt="Screenshot 2022-01-03 at 16 30 37" src="https://user-images.githubusercontent.com/13132571/147949215-c961d7ee-c588-4630-a371-956a72802c3a.png"><img width="842" alt="Screenshot 2022-01-03 at 16 30 53" src="https://user-images.githubusercontent.com/13132571/147949231-dccf532c-ae34-4c28-82e5-bc269ab01df5.png">

Det tilsvarende stacktrace ville have set gigantisk ud fordi der medtages omkring ti nedslag i click kodebasen, endnu værre hvis fejlen ikke bare var kunstig men faktisk kom fra SQLAlchemy. Begge kan sorteres fra med `rich` hvilket er ret lækkert. Også fedt at værdien af de lokale variable hvor fejlen opstår skrives på skærmen.

Der er stort potentiale i `rich`, fx til at skrive tabeller og andet ikke-triviel tekst i terminalen.