### PR TITLE
Gør åbning af filer med fire niv konfigurerbar

### DIFF
--- a/docs/konfiguration.rst
+++ b/docs/konfiguration.rst
@@ -11,6 +11,7 @@ måde:
 
     [general]
     default_connection = prod
+    niv_open_files = true
 
     [prod_connection]
     password = <adgangskode>

--- a/fire/api/configuration.py
+++ b/fire/api/configuration.py
@@ -20,7 +20,10 @@ RC_PATHS = (
 )
 
 RC_DEFAULTS = {
-    "general": {"default_connection": "prod"},
+    "general": {
+        "default_connection": "prod",
+        "niv_open_files": "true",
+    },
     # se https://www.gnu.org/software/gama/manual/gama.html#Network-SQL-definition
     "network-attributes": {
         "axes-xy": "en",

--- a/fire/api/firedb/__init__.py
+++ b/fire/api/firedb/__init__.py
@@ -133,7 +133,7 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
             )
 
         sql = text(
-            fr"""SELECT
+            rf"""SELECT
                     max(to_number(
                         regexp_substr(pi.tekst, 'G.I.(.+)', 1, 1, '', 1)
                     )) lbnr
@@ -284,7 +284,7 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
         """
         landsnr = self.hent_punktinformationtype("IDENT:landsnr")
         sql = text(
-            fr"""SELECT lbnr
+            rf"""SELECT lbnr
                 FROM (
                     SELECT
                         regexp_substr(tekst, '.*-.*-(.+)', 1, 1, '', 1) lbnr

--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -3,6 +3,7 @@ Kommandoliniebrugergrænsefladen (en command-line interface, CLI) til FIREs API.
 
 """
 import sys
+import os
 
 import click
 
@@ -124,3 +125,14 @@ def override_firedb(new_firedb: FireDb):
     """
     global firedb
     firedb = new_firedb
+
+
+def åbn_fil(fil: str) -> None:
+    """
+    Åben en fil med et passende program.
+
+    Wrapperfunktion til os.startfile, der gør det muligt at undlade filåbning
+    ved hjælp af indstilling i konfigurationsfil (`niv_open_files`).
+    """
+    if "startfile" in dir(os) and firedb.config.getboolean("general", "niv_open_files"):
+        os.startfile(fil)

--- a/fire/cli/niv/_ilæg_revision.py
+++ b/fire/cli/niv/_ilæg_revision.py
@@ -94,54 +94,54 @@ def opret_punktnavne_til_ikke_oprettede_punkter(ark: pd.DataFrame) -> pd.DataFra
 
 def udfyld_udeladte_identer(ark: pd.DataFrame) -> pd.DataFrame:
     """
-    Udfyld celler med udeladt ident i kolonnen Punkt.
+     Udfyld celler med udeladt ident i kolonnen Punkt.
 
-    Første linje/række af punkt-oplysningerne har punktets
-    ident i kolonnen Punkt, hvilket indikerer starten på et
-    nyt punkts informationer.
+     Første linje/række af punkt-oplysningerne har punktets
+     ident i kolonnen Punkt, hvilket indikerer starten på et
+     nyt punkts informationer.
 
-    Formålet med funktionen er at tilføje punktets ident
-    til hver række med punktoplysninger for punktet og
-    frem til starten af næste punkt.
+     Formålet med funktionen er at tilføje punktets ident
+     til hver række med punktoplysninger for punktet og
+     frem til starten af næste punkt.
 
-   Eksempel
-    --------
+    Eksempel
+     --------
 
-        Før
+         Før
 
-        |   Punkt   |         Attribut        | ... |
-        |-----------|-------------------------|-----|
-        |  SKEJ     | LOKATION                |     |
-        |           | ATTR:muligt_datumstabil |     |
-        |           | ...                     |     |
-        |           |                         |     |
-        |           |                         |     |
-        |  FYNO     | LOKATION                |     |
-        |           | ATTR:muligt_datumstabil |     |
-        |           | ...                     |     |
-        |           |                         |     |
-        |           |                         |     |
-        |  OTTO     | LOKATION                |     |
-        |           | ATTR:muligt_datumstabil |     |
-        |           | ...                     |     |
+         |   Punkt   |         Attribut        | ... |
+         |-----------|-------------------------|-----|
+         |  SKEJ     | LOKATION                |     |
+         |           | ATTR:muligt_datumstabil |     |
+         |           | ...                     |     |
+         |           |                         |     |
+         |           |                         |     |
+         |  FYNO     | LOKATION                |     |
+         |           | ATTR:muligt_datumstabil |     |
+         |           | ...                     |     |
+         |           |                         |     |
+         |           |                         |     |
+         |  OTTO     | LOKATION                |     |
+         |           | ATTR:muligt_datumstabil |     |
+         |           | ...                     |     |
 
-        Efter
+         Efter
 
-        |   Punkt   |         Attribut        | ... |
-        |-----------|-------------------------|-----|
-        |  SKEJ     | LOKATION                |     |
-        |  SKEJ     | ATTR:muligt_datumstabil |     |
-        |  SKEJ     | ...                     |     |
-        |  SKEJ     |                         |     |
-        |  SKEJ     |                         |     |
-        |  FYNO     | LOKATION                |     |
-        |  FYNO     | ATTR:muligt_datumstabil |     |
-        |  FYNO     | ...                     |     |
-        |  FYNO     |                         |     |
-        |  FYNO     |                         |     |
-        |  OTTO     | LOKATION                |     |
-        |  OTTO     | ATTR:muligt_datumstabil |     |
-        |  OTTO     | ...                     |     |
+         |   Punkt   |         Attribut        | ... |
+         |-----------|-------------------------|-----|
+         |  SKEJ     | LOKATION                |     |
+         |  SKEJ     | ATTR:muligt_datumstabil |     |
+         |  SKEJ     | ...                     |     |
+         |  SKEJ     |                         |     |
+         |  SKEJ     |                         |     |
+         |  FYNO     | LOKATION                |     |
+         |  FYNO     | ATTR:muligt_datumstabil |     |
+         |  FYNO     | ...                     |     |
+         |  FYNO     |                         |     |
+         |  FYNO     |                         |     |
+         |  OTTO     | LOKATION                |     |
+         |  OTTO     | ATTR:muligt_datumstabil |     |
+         |  OTTO     | ...                     |     |
 
 
     """

--- a/fire/cli/niv/_opret_sag.py
+++ b/fire/cli/niv/_opret_sag.py
@@ -118,7 +118,5 @@ def opret_sag(projektnavn: str, beskrivelse: str, sagsbehandler: str, **kwargs) 
     }
 
     if skriv_ark(projektnavn, resultater):
-        # os.startfile() er kun tilgængelig på Windows
-        if "startfile" in dir(os):
-            fire.cli.print("Færdig! - åbner regneark for check.")
-            os.startfile(f"{projektnavn}.xlsx")
+        fire.cli.print("Færdig!")
+        fire.cli.åbn_fil(f"{projektnavn}.xlsx")

--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 import webbrowser
@@ -96,10 +95,10 @@ def regn(projektnavn: str, **kwargs) -> None:
         infiks=infiks,
     )
     skriv_ark(projektnavn, resultater)
-    webbrowser.open_new_tab(htmlrapportnavn)
-    if "startfile" in dir(os):
+    if fire.cli.firedb.config.getboolean("general", "niv_open_files"):
+        webbrowser.open_new_tab(htmlrapportnavn)
         fire.cli.print("Færdig! - åbner regneark og resultatrapport for check.")
-        os.startfile(f"{projektnavn}.xlsx")
+        fire.cli.åbn_fil(f"{projektnavn}.xlsx")
 
 
 # ------------------------------------------------------------------------------

--- a/fire/cli/niv/_udtræk_revision.py
+++ b/fire/cli/niv/_udtræk_revision.py
@@ -119,20 +119,17 @@ def lokationskoordinat_streng(lokation: tuple[float, float]) -> str:
     return f"{lokation[1]:.3f} m   {lokation[0]:.3f} m"
 
 
+def punkt_informationer_aktive(
+    punkt_informationer: list[PunktInformation],
+) -> list[PunktInformation]:
+    return [info for info in punkt_informationer if info.registreringtil is None]
 
-def punkt_informationer_aktive(punkt_informationer: list[PunktInformation]) -> list[PunktInformation]:
+
+def fjern_ignorerede(
+    punkt_informationer: list[PunktInformation], ignorerede: list[str]
+) -> list[PunktInformation]:
     return [
-        info
-        for info in punkt_informationer
-        if info.registreringtil is None
-    ]
-
-
-def fjern_ignorerede(punkt_informationer: list[PunktInformation], ignorerede: list[str]) -> list[PunktInformation]:
-    return [
-        info
-        for info in punkt_informationer
-        if info.infotype.name not in ignorerede
+        info for info in punkt_informationer if info.infotype.name not in ignorerede
     ]
 
 
@@ -141,16 +138,18 @@ def har_landsnr_lig_ident(info: PunktInformation, ident: str) -> bool:
     return info.infotype.name == "IDENT:landsnr" and info.tekst == ident
 
 
-def fjern_alle_med_ident(punkt_informationer: list[PunktInformation], ident: str) -> list[PunktInformation]:
+def fjern_alle_med_ident(
+    punkt_informationer: list[PunktInformation], ident: str
+) -> list[PunktInformation]:
     return [
-        info
-        for info in punkt_informationer
-        if not har_landsnr_lig_ident(info, ident)
+        info for info in punkt_informationer if not har_landsnr_lig_ident(info, ident)
     ]
 
 
 def flyt_attributter_til_toppen(
-    punkt_informationer: list[PunktInformation], *, prioritering: list[str] = ATTRIBUT_PRIORITERING
+    punkt_informationer: list[PunktInformation],
+    *,
+    prioritering: list[str] = ATTRIBUT_PRIORITERING,
 ) -> list:
     """
     Find prioriterede attributter og placér dem øverst i samme rækkefølge.
@@ -159,6 +158,7 @@ def flyt_attributter_til_toppen(
     deres rækkefølge i forhold til hinanden forbliver uændret.
 
     """
+
     def key(info: PunktInformation) -> int:
         if info.infotype.name not in prioritering:
             return 9999
@@ -175,11 +175,7 @@ mulig_datumstabil = partial(har_infotype, attribut="ATTR:muligt_datumstabil")
 
 
 def har_attr_muligt_datumstabil(punkt_informationer: list[PunktInformation]) -> bool:
-    return any(
-        mulig_datumstabil(punkt_info)
-        for punkt_info
-        in punkt_informationer
-    )
+    return any(mulig_datumstabil(punkt_info) for punkt_info in punkt_informationer)
 
 
 @niv_command_group.command()
@@ -261,7 +257,9 @@ def udtræk_revision(
 
         # Fjern punktinformationer, der ikke skal skrives til arket
         punkt_informationer = punkt_informationer_aktive(punkt.punktinformationer)
-        punkt_informationer = fjern_ignorerede(punkt_informationer, ignorerede_attributter)
+        punkt_informationer = fjern_ignorerede(
+            punkt_informationer, ignorerede_attributter
+        )
         punkt_informationer = fjern_alle_med_ident(punkt_informationer, ident)
 
         # Inden punkt-informationerne føjes til regnearket, flyt

--- a/flame/help/source/conf.py
+++ b/flame/help/source/conf.py
@@ -40,8 +40,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Fire"
-copyright = u"2013, Septima"
+project = "Fire"
+copyright = "2013, Septima"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -178,7 +178,7 @@ htmlhelp_basename = "TemplateClassdoc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "Fire.tex", u"Fire Documentation", u"Septima", "manual"),
+    ("index", "Fire.tex", "Fire Documentation", "Septima", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -209,4 +209,4 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "TemplateClass", u"Fire Documentation", [u"Septima"], 1)]
+man_pages = [("index", "TemplateClass", "Fire Documentation", ["Septima"], 1)]

--- a/scripts/load_shapefile.py
+++ b/scripts/load_shapefile.py
@@ -25,7 +25,7 @@ with fiona.open(Path(__file__).parent / "../data/herredsogn.shp") as herredsogn:
         # ved at splitte wkt-strengen i flere dele og sammensætte den med ||-operatoren i SQL udtrykket.
         # Idioti, men det virker.
         n = len(g.wkt) // 3
-        wkt1, wkt2, wkt3 = g.wkt[:n], g.wkt[n: 2 * n + 1], g.wkt[2 * n + 1:]
+        wkt1, wkt2, wkt3 = g.wkt[:n], g.wkt[n : 2 * n + 1], g.wkt[2 * n + 1 :]
 
         try:
             sql = f"""INSERT INTO herredsogn (kode, geometri)

--- a/test/api/niv/test_ilæg_revision.py
+++ b/test/api/niv/test_ilæg_revision.py
@@ -38,4 +38,6 @@ def test_udfyld_udeladte_identer():
     expected = nyt_ark(arkdef.REVISION).append(output_data, ignore_index=True)
 
     result = udfyld_udeladte_identer(ark)
-    assert all(result.Punkt == expected.Punkt), f"Expected \n\n{result}\n\nto be\n\n{expected}\n\n."
+    assert all(
+        result.Punkt == expected.Punkt
+    ), f"Expected \n\n{result}\n\nto be\n\n{expected}\n\n."

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,7 @@ class DummyFireDb(FireDb):
 
 
 persistent_firedb = FireDb(db="ci", debug=False)
+persistent_firedb.config.set("general", "niv_open_files", "false")
 fire.cli.override_firedb(persistent_firedb)
 
 


### PR DESCRIPTION
Giver brugeren mulighed for at undgå at regneark åbnes automatisk
efter endt `fire niv` kommando. Formentligt primært anvendeligt
for udviklere. Det er da også netop forbedret udvikling der er
anledning til dette commit: Afvikling af test-suiten på Windows
fejler når regneark åbnes af `fire niv xxx`. Derfor slås åbning af
filerne fra i test-suitens instans af FireDb.