### PR TITLE
Simplificer sags(event)oprettelse

### DIFF
--- a/fire/api/firedb/__init__.py
+++ b/fire/api/firedb/__init__.py
@@ -15,6 +15,8 @@ from fire.api.model import (
     PunktInformationType,
     GeometriObjekt,
     Bbox,
+    Sag,
+    Sagsinfo,
     Sagsevent,
     FikspunktsType,
 )
@@ -53,6 +55,24 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
         if not result:
             raise NoResultFound
         return result
+
+    def ny_sag(self, behandler: str, beskrivelse: str) -> Sag:
+        """
+        Fabrik til oprettelse af nye sager.
+
+        Oprettede sager er altid aktive, samt tilføjet og flushed
+        på databasesessionen.
+        """
+        sagsinfo = Sagsinfo(
+            aktiv="true",
+            behandler=behandler,
+            beskrivelse=beskrivelse,
+        )
+        sag = Sag(sagsinfos=[sagsinfo])
+        self.session.add(sag)
+        self.session.flush()
+
+        return sag
 
     def tilknyt_landsnumre(
         self,

--- a/fire/cli/grafik/__init__.py
+++ b/fire/cli/grafik/__init__.py
@@ -137,15 +137,9 @@ def indsæt(
                 raise SystemExit
 
     # sagshåndtering
-    sag = Sag(
-        id=fire.uuid(),
-        sagsinfos=[
-            Sagsinfo(
-                aktiv="true",
-                behandler=sagsbehandler,
-                beskrivelse="Indsættelse af ny grafik med 'fire grafik'",
-            )
-        ],
+    sag = db.ny_sag(
+        behandler=sagsbehandler,
+        beskrivelse="Indsættelse af ny grafik med 'fire grafik'",
     )
     db.indset_sag(sag, commit=False)
     try:
@@ -159,14 +153,8 @@ def indsæt(
     grafik.type = type
     grafik.filnavn = filnavn
 
-    sagsevent = Sagsevent(
-        sag=sag,
-        eventtype=EventType.GRAFIK_INDSAT,
-        sagseventinfos=[
-            SagseventInfo(
-                beskrivelse=f"Grafik {filnavn} indsættes på punkt {punkt.ident}"
-            )
-        ],
+    sagsevent = sag.ny_sagsevent(
+        f"Grafik {filnavn} indsættes på punkt {punkt.ident}",
         grafikker=[grafik],
     )
     db.indset_sagsevent(sagsevent, commit=False)
@@ -218,15 +206,9 @@ def slet(filnavn: str, sagsbehandler: str, **kwargs) -> None:
     punkt = grafik.punkt
 
     # sagshåndtering
-    sag = Sag(
-        id=fire.uuid(),
-        sagsinfos=[
-            Sagsinfo(
-                aktiv="true",
-                behandler=sagsbehandler,
-                beskrivelse="Afregistrering af grafik med `fire grafik slet`",
-            )
-        ],
+    sag = db.ny_sag(
+        behandler=sagsbehandler,
+        beskrivelse="Afregistrering af grafik med `fire grafik slet`",
     )
     db.indset_sag(sag, commit=False)
     try:
@@ -235,15 +217,11 @@ def slet(filnavn: str, sagsbehandler: str, **kwargs) -> None:
         fire.cli.firedb.session.rollback()
         raise SystemExit(ex)
 
-    sagsevent = Sagsevent(
-        sag=sag,
-        sagseventinfos=[
-            SagseventInfo(
-                beskrivelse=f"Grafik {filnavn} for {punkt.ident} afregistreret"
-            )
-        ],
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse=f"Grafik {filnavn} for {punkt.ident} afregistreret",
+        grafikker_slettede=[grafik],
     )
-    db.luk_grafik(grafik, sagsevent, commit=False)
+    db.indset_sagsevent(sagsevent, commit=False)
     db.luk_sag(sag, commit=False)
     try:
         # Indsæt alle objekter i denne session

--- a/fire/cli/niv/_ilæg_revision.py
+++ b/fire/cli/niv/_ilæg_revision.py
@@ -20,8 +20,6 @@ from fire.api.model import (
     Punkt,
     PunktInformation,
     PunktInformationTypeAnvendelse,
-    Sagsevent,
-    SagseventInfo,
     FikspunktsType,
 )
 from fire.io.regneark import arkdef
@@ -300,11 +298,8 @@ def ilæg_revision(
             )
 
     if len(nye_punkter) > 0 or len(nye_lokationer) > 0:
-        sagsevent = Sagsevent(
-            id=uuid(),
-            sagsid=sag.id,
-            sagseventinfos=[SagseventInfo(beskrivelse="Oprettelse af nye punkter")],
-            eventtype=EventType.PUNKT_OPRETTET,
+        sagsevent = sag.ny_sagsevent(
+            beskrivelse="Oprettelse af nye punkter",
             punkter=nye_punkter,
             geometriobjekter=nye_lokationer,
         )
@@ -400,11 +395,8 @@ def ilæg_revision(
             f"Opdatering af {n} koordinater til {', '.join(punktnavne)}"
         )
 
-        sagsevent = Sagsevent(
-            id=uuid(),
-            sagsid=sag.id,
-            sagseventinfos=[SagseventInfo(beskrivelse=koordinatoprettelsestekst)],
-            eventtype=EventType.KOORDINAT_BEREGNET,
+        sagsevent = sag.ny_sagsevent(
+            beskrivelse=koordinatoprettelsestekst,
             koordinater=nye_koordinater,
         )
         fire.cli.firedb.indset_sagsevent(sagsevent, commit=False)
@@ -611,29 +603,20 @@ def ilæg_revision(
         punkter_med_oprettelse.add(p.ident)
 
     if len(til_opret) > 0 or len(til_ret) > 0:
-        sagsevent = Sagsevent(
-            id=uuid(),
-            sagsid=sag.id,
-            sagseventinfos=[
-                SagseventInfo(beskrivelse="Opdatering af punktinformationer")
-            ],
+        sagsevent = sag.ny_event(
+            beskrivelse="Opdatering af punktinformationer",
             eventtype=EventType.PUNKTINFO_TILFOEJET,
             punktinformationer=[*til_opret, *til_ret],
         )
-
         fire.cli.firedb.indset_sagsevent(sagsevent, commit=False)
         sagsgang = opdater_sagsgang(sagsgang, sagsevent, sagsbehandler)
         flush()
 
     if len(til_sluk) > 0:
-        sagsevent = Sagsevent(
-            id=uuid(),
-            sagsid=sag.id,
-            sagseventinfos=[SagseventInfo(beskrivelse="Lukning af punktinformationer")],
-            eventtype=EventType.PUNKTINFO_FJERNET,
+        sagsevent = sag.ny_sagsevent(
+            beskrivelse="Lukning af punktinformationer",
             punktinformationer_slettede=til_sluk,
         )
-
         fire.cli.firedb.indset_sagsevent(sagsevent, commit=False)
         sagsgang = opdater_sagsgang(sagsgang, sagsevent, sagsbehandler)
         flush()

--- a/fire/cli/niv/_luk_sag.py
+++ b/fire/cli/niv/_luk_sag.py
@@ -53,29 +53,22 @@ def luk_sag(projektnavn: str, sagsbehandler, **kwargs) -> None:
             zipobj.write(fil)
 
     # Tilføj materiale til sagsevent
-    sagseventtekst = f"Sagsmateriale for {projektnavn}"
-    sagsevent = Sagsevent(
-        sag=sag,
-        eventtype=EventType.KOMMENTAR,
-        sagseventinfos=[
-            SagseventInfo(
-                beskrivelse=sagseventtekst,
-                materialer=[SagseventInfoMateriale(materiale=zipped.getvalue())],
-            ),
-        ],
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse=f"Sagsmateriale for {projektnavn}",
+        materialer=[zipped.getvalue()],
     )
     fire.cli.firedb.indset_sagsevent(sagsevent, commit=False)
-
     fire.cli.firedb.luk_sag(sag, commit=False)
     try:
         # Indsæt alle objekter i denne session
         fire.cli.firedb.session.flush()
-    except:
+    except Exception as ex:
         # rul tilbage hvis databasen smider en exception
         fire.cli.firedb.session.rollback()
         fire.cli.print(
             f"Der opstod en fejl - sag {sag.id} for '{projektnavn}' IKKE lukket!"
         )
+        fire.cli.print(f"Mulig årsag: {ex}")
     else:
         spørgsmål = click.style(
             f"Er du sikker på at du vil lukke sagen {projektnavn}?",
@@ -96,7 +89,7 @@ def luk_sag(projektnavn: str, sagsbehandler, **kwargs) -> None:
         "Dato": pd.Timestamp.now(),
         "Hvem": sagsbehandler,
         "Hændelse": "sagslukning",
-        "Tekst": sagseventtekst,
+        "Tekst": sagsevent.beskrivelse,
         "uuid": sagsevent.id,
     }
     sagsgang = sagsgang.append(sagsgangslinje, ignore_index=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,8 @@ from fire.api.model import (
     EventType,
     Srid,
     Boolean,
+    GeometriObjekt,
+    Point,
 )
 from fire.io.regneark import (
     arkdef,
@@ -93,7 +95,12 @@ def punktfabrik(firedb, sagsevent: Sagsevent):
 
     def fabrik():
         sagsevent.eventtype = EventType.PUNKT_OPRETTET
-        p = Punkt(sagsevent=sagsevent)
+        p = Punkt(
+            sagsevent=sagsevent,
+            geometriobjekter=[
+                GeometriObjekt(sagsevent=sagsevent, geometri=Point((12.1, 55.5)))
+            ],
+        )
         firedb.session.add(p)
         return p
 

--- a/test/niv/test_niv.py
+++ b/test/niv/test_niv.py
@@ -52,6 +52,7 @@ def test_revision(mocker):
         mocker.patch("fire.cli.niv._ilæg_nye_punkter.bekræft", return_value=True)
         result = runner.invoke(niv, ["ilæg-nye-punkter", "testsag"])
         print(result.output)
+        print(result)
         assert result.exit_code == 0
 
         # fire niv luk-sag test
@@ -107,5 +108,6 @@ def test_observationer(mocker):
         # fire niv luk-sag test
         mocker.patch("fire.cli.niv._luk_sag.bekræft", return_value=True)
         result = runner.invoke(niv, ["luk-sag", "testsag"])
+        print(result)
         print(result.output)
         assert result.exit_code == 0

--- a/test/test_sag.py
+++ b/test/test_sag.py
@@ -1,9 +1,12 @@
 import os
+from typing import Callable
 
 import pytest
 
+import fire
 from fire.api import FireDb
 from fire.api.model import (
+    Punkt,
     Sag,
     Sagsinfo,
     Sagsevent,
@@ -85,3 +88,156 @@ def test_luk_sag(firedb: FireDb, sag: Sag):
 
     with pytest.raises(TypeError):
         firedb.luk_sag(4242)
+
+
+def test_ny_sag(firedb: FireDb):
+    """
+    Test FireDb.ny_sag()
+    """
+    sag = firedb.ny_sag("teste testesen", "sag til test")
+
+    assert sag.id is not None
+    assert sag.registreringfra is not None
+    assert sag.behandler == "teste testesen"
+
+    firedb.session.rollback()
+
+
+def test_ny_sagsevent(firedb: FireDb, sag: Sag, punktfabrik: Callable):
+    """
+    Test 'simple' inputs til Sag.ny_sagsevent()
+    """
+
+    # Indsættelse af punkt tester scenarie hvor kun "obligatorisk"
+    # data for en eventtype er tilgængeligt.
+    punkt = punktfabrik()
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse="tests",
+        punkter=[punkt],
+    )
+
+    # Sikr at id er tildelt før flush()
+    assert sagsevent.id is not None
+
+    firedb.indset_sagsevent(sagsevent, commit=False)
+    firedb.session.flush()
+
+    assert sagsevent.sag == sag
+    assert sagsevent.id is not None
+    assert sagsevent.eventtype == EventType.PUNKT_OPRETTET
+    assert sagsevent.beskrivelse == "tests"
+
+    # Indsættelse af punkt+geometriobjekt tester scenarie hvor både "obligatorisk"
+    # og "valgfri" data for en eventtype er tilgængeligt.
+    punkt = punktfabrik()
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse="tests",
+        punkter=[punkt],
+        geometriobjekter=[punkt.geometriobjekter[0]],
+    )
+
+    # Sikr at id er tildelt før flush()
+    assert sagsevent.id is not None
+
+    firedb.indset_sagsevent(sagsevent, commit=False)
+    firedb.session.flush()
+
+    assert sagsevent.sag == sag
+    assert sagsevent.id is not None
+    assert sagsevent.eventtype == EventType.PUNKT_OPRETTET
+    assert sagsevent.beskrivelse == "tests"
+
+    uuid = fire.uuid()
+    sagseventid = sag.ny_sagsevent(
+        beskrivelse="kommentar",
+        id=uuid,
+    )
+
+    assert sagseventid.id == uuid
+    firedb.indset_sagsevent(sagseventid, commit=False)
+    firedb.session.flush()
+    assert sagseventid.id == uuid
+
+    firedb.session.rollback()
+
+
+def test_ny_sagsevent_data(firedb: FireDb, sag: Sag, punktfabrik: Callable):
+    """
+    Test indsættelse af data direkte med Sag.ny_sagsevent().
+    """
+    punkter = [punktfabrik() for _ in range(5)]
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse="tests",
+        punkter=punkter,
+    )
+    firedb.indset_sagsevent(sagsevent, commit=False)
+    firedb.session.flush()
+
+    assert len(sagsevent.punkter) == len(punkter)
+    assert punkter[0].sagsevent.id == sagsevent.id
+    assert sagsevent.punkter[0] == punkter[0]
+    assert punkter[0].id is not None
+
+    firedb.session.rollback()
+
+
+def test_ny_sagsevent_materiale(firedb: FireDb, sag: Sag):
+    """
+    Test tilknyttelse af materiale til et sagsevent.
+    """
+
+    html = "<html><title>Test</test><body>This is a test</body></html>"
+    blob = os.urandom(1000)
+
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse="Indsæt materiale",
+        htmler=[html],
+        materialer=[blob],
+    )
+    firedb.indset_sagsevent(sagsevent, commit=False)
+    firedb.session.flush()
+
+    assert sagsevent.sagseventinfos[0].materialer[0].materiale == blob
+    assert sagsevent.sagseventinfos[0].htmler[0].html == html
+
+    firedb.session.rollback()
+
+
+def test_ny_sagsevent_ukendt(firedb: FireDb, sag: Sag):
+    """
+    Test at der fejles retmæssigt ved forsøg på tilknyttelse af ukendte
+    objekttyper til Sagsevent.
+    """
+
+    with pytest.raises(ValueError):
+        sag.ny_sagsevent(
+            beskrivelse="Test tilknytning af ukendt objekttype",
+            kafferkopper=["kaffe", "kop", "kendes", "ikke"],
+        )
+
+
+def test_ny_sagsevent_slettede(firedb: FireDb, sag: Sag, koordinatfabrik: Callable):
+    """
+    Test at slettede objekter afregistreres korrekt når `Sag.ny_sagsevent()`
+    benyttes.
+    """
+    koordinater = [koordinatfabrik() for _ in range(5)]
+
+    sagsevent = sag.ny_sagsevent(
+        beskrivelse="tests",
+        koordinater=koordinater,
+    )
+
+    firedb.indset_sagsevent(sagsevent, commit=False)
+    firedb.session.flush()
+
+    sagsevent_slettede = sag.ny_sagsevent(
+        beskrivelse="Fjern punkter igen",
+        koordinater_slettede=koordinater,
+    )
+
+    firedb.indset_sagsevent(sagsevent_slettede, commit=False)
+    firedb.session.flush()
+
+    for i in range(5):
+        assert koordinater[i].registreringtil is not None


### PR DESCRIPTION
Tilføjer to "genveje" til nemmere håndtering af sager og sagsevents. En sag kan nu oprettes uden at skulle bakse med `Sagsinfo` og andet "fyld":

```python
sag = firedb.ny_sag(
    behandler=sagsbehandler,
    beskrivelse="Indsættelse af ny grafik med 'fire grafik'",
)
```
som står i kontrast til den tidligere måde at oprette en sag på:
```python
sag = Sag(
    id=fire.uuid(),
    sagsinfos=[
        Sagsinfo(
            aktiv="true",
            behandler=sagsbehandler,
            beskrivelse="Indsættelse af ny grafik med 'fire grafik'",
        )
    ]
```

Tilsvarende er oprettelse af sagsevents forsimplet:

```python
sagsevent = sag.ny_sagsevent(
    beskrivelse=f"Sagsmateriale for {projektnavn}",
    materialer=[zipped.getvalue()],
)
```

hvor man tidligere har skulle folde det hele mere ud:

```python
sagsevent = Sagsevent(
    sag=sag,
    eventtype=EventType.KOMMENTAR,
    sagseventinfos=[
        SagseventInfo(
            beskrivelse=f"Sagsmateriale for {projektnavn}"
            materialer=[SagseventInfoMateriale(materiale=zipped.getvalue())],
        ),
    ],
)
```

Den hidtidige metode til oprettelse af sager og sagsevents eksisterer endnu og er stadig i brug i dele af kodebasen. Især i `fire niv`-programmerne, hvor det vil kræve en større omskrivning at justere programmerne til den nye metode.