### PR TITLE
Tilføj script til genoprettelse af testdatabasens indhold

### DIFF
--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -1,0 +1,21 @@
+# Nulstil testdatabase.
+#
+# Kald fra roden af repository:
+#
+# fire$ ./scripts/reset-test-db.sh
+#
+# Køres scriptet uden argumenter forbindes til database på localhost.
+# Tilføj adresse på databasen for at nulstille remote, fx:
+#
+# fire$ ./scripts/reset-test-db.sh 192.168.0.81
+
+export NLS_LANG=.AL32UTF8
+
+HOSTNAME=${1:-localhost}
+
+echo exit | ORACLE_PATH=misc/oracle sqlplus -S fire/fire@//"$HOSTNAME":1521/XEPDB1 @sql/sweep_db.sql
+
+echo exit | ORACLE_PATH=misc/oracle sqlplus -S fire/fire@//"$HOSTNAME":1521/XEPDB1 @sql/ddl.sql
+echo exit | ORACLE_PATH=misc/oracle sqlplus -S fire/fire@//"$HOSTNAME":1521/XEPDB1 @test/sql/testdata.sql
+
+python scripts/load_shapefile.py

--- a/sql/sweep_db.sql
+++ b/sql/sweep_db.sql
@@ -1,0 +1,39 @@
+-----------------------------------------------------------------------------------------
+--                                FJERN ALLE TABELLER
+--
+-- Fjerner alle tabeller og tilhørende index, triggers m.m. med henblik på let at kunne
+-- reetablere databasen i forbindelse med tests af ændringer i DDL eller testmateriale.
+--
+-- Som udgangspunkt fjernes 'herredsogn'-tabellen IKKE, da den typisk ikke ændrer sig
+-- og tager en del tid at indlæse.
+-----------------------------------------------------------------------------------------
+
+DROP TABLE  beregning               CASCADE CONSTRAINTS;
+DROP TABLE  beregning_koordinat     CASCADE CONSTRAINTS;
+DROP TABLE  beregning_observation   CASCADE CONSTRAINTS;
+DROP TABLE  eventtype               CASCADE CONSTRAINTS;
+DROP TABLE  geometriobjekt          CASCADE CONSTRAINTS;
+DROP TABLE  herredsogn              CASCADE CONSTRAINTS;
+DROP TABLE  koordinat               CASCADE CONSTRAINTS;
+DROP TABLE  tidsserie               CASCADE CONSTRAINTS;
+DROP TABLE  tidsserie_koordinat     CASCADE CONSTRAINTS;
+DROP TABLE  observation             CASCADE CONSTRAINTS;
+DROP TABLE  observationstype        CASCADE CONSTRAINTS;
+DROP TABLE  punkt                   CASCADE CONSTRAINTS;
+DROP TABLE  punktsamling            CASCADE CONSTRAINTS;
+DROP TABLE  punktsamling_punkt      CASCADE CONSTRAINTS;
+DROP TABLE  punktinfo               CASCADE CONSTRAINTS;
+DROP TABLE  punktinfotype           CASCADE CONSTRAINTS;
+DROP TABLE  grafik                  CASCADE CONSTRAINTS;
+DROP TABLE  sag                     CASCADE CONSTRAINTS;
+DROP TABLE  sagsevent               CASCADE CONSTRAINTS;
+DROP TABLE  sagseventinfo           CASCADE CONSTRAINTS;
+DROP TABLE  sagseventinfo_html      CASCADE CONSTRAINTS;
+DROP TABLE  sagseventinfo_materiale CASCADE CONSTRAINTS;
+DROP TABLE  sagsinfo                CASCADE CONSTRAINTS;
+DROP TABLE  sridtype                CASCADE CONSTRAINTS;
+
+DELETE FROM user_sdo_geom_metadata WHERE table_name='GEOMETRIOBJEKT';
+DELETE FROM user_sdo_geom_metadata WHERE table_name='HERREDSOGN';
+
+COMMIT;


### PR DESCRIPTION
Særdeles nyttigt når der under udvikling ændres på DDL eller test- databasens indhold. Gør det muligt at nulstille tabellerne uden at skulle gentarte hele databasen. Sparer en del tid.