### PR TITLE
Ret fejl i kald af Sag.ny_sagsevent

### DIFF
--- a/fire/cli/grafik/__init__.py
+++ b/fire/cli/grafik/__init__.py
@@ -154,7 +154,7 @@ def indsæt(
     grafik.filnavn = filnavn
 
     sagsevent = sag.ny_sagsevent(
-        f"Grafik {filnavn} indsættes på punkt {punkt.ident}",
+        beskrivelse=f"Grafik {filnavn} indsættes på punkt {punkt.ident}",
         grafikker=[grafik],
     )
     db.indset_sagsevent(sagsevent, commit=False)

--- a/fire/cli/niv/_ilæg_revision.py
+++ b/fire/cli/niv/_ilæg_revision.py
@@ -602,9 +602,8 @@ def ilæg_revision(
         punkter_med_oprettelse.add(p.ident)
 
     if len(til_opret) > 0 or len(til_ret) > 0:
-        sagsevent = sag.ny_event(
+        sagsevent = sag.ny_sagsevent(
             beskrivelse="Opdatering af punktinformationer",
-            eventtype=EventType.PUNKTINFO_TILFOEJET,
             punktinformationer=[*til_opret, *til_ret],
         )
         fire.cli.firedb.indset_sagsevent(sagsevent, commit=False)


### PR DESCRIPTION
Enkelte steder er forkert funktionsnavn brugt eller manglende angivelse af parameternavn (beskrivelse).

Opfølgning på #628