### PR TITLE
fire niv: Slæk versionsnummercheck ved læsning af sagsfiler

### DIFF
--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -11,6 +11,7 @@ from typing import (
 import click
 import pandas as pd
 from sqlalchemy.orm.exc import NoResultFound
+import packaging.version
 
 from fire.api.model import (
     Punkt,
@@ -569,7 +570,7 @@ def opret_region_punktinfo(punkt: Punkt) -> PunktInformation:
     return PunktInformation(infotype=pit, punkt=punkt)
 
 
-def er_projekt_okay(projektnavn: str):
+def er_projekt_okay(projektnavn: str) -> None:
     """
     Kontroller om det er okay at bruge et givet projekt.
 
@@ -586,14 +587,23 @@ def er_projekt_okay(projektnavn: str):
         )
         raise SystemExit(1)
 
-    versionsnummer = find_parameter(projektnavn, "Version")
-    if versionsnummer != fire.__version__:
+    fil_version = packaging.version.parse(find_parameter(projektnavn, "Version"))
+    fire_version = packaging.version.parse(fire.__version__)
+    if fil_version.major != fire_version.major:
         fire.cli.print(
-            f"FEJL: '{projektnavn}' er oprettet med version {versionsnummer} - du har version {fire.__version__} installeret!",
+            f"FEJL: '{projektnavn}' er oprettet med version {fil_version} - du har version {fire_version} installeret!",
             bold=True,
             bg="red",
         )
         raise SystemExit(1)
+
+    if fil_version.minor > fire_version.minor:
+        fire.cli.print(
+            f"ADVARSEL: '{projektnavn}' er oprettet med version {fil_version} - du har version {fire_version} installeret!",
+            bold=True,
+            bg="yellow",
+        )
+        return
 
 
 """


### PR DESCRIPTION
Forskelle i patch-nummer ignoreres, da der ikke bør være forskel i funktionalitet mellem disse versioner.

Forskelle i minorversion resulterer i en advarsel hvis filens minorversion er større end den installerede version af FIRE, da der potentielt kan være ny funktionalitet i den højere version.

Forskelle i majorversion resulterer i en fejl og programmet afbrydes. Det må forventes at der er store ændringer i funktionalitet, der forhindrer bagudkompatibilitet. Det er et teoretisk anliggende på nuværende tidspunkt og bør tages op til overvejelse den dag en version 2 af FIRE skal i omløb.

### EKSEMPLER

Eksempler på adfærd ved forskelle i patch, minor og major numre.

Patch-version afviger fra installeret version. Ingen anmærkninger fra FIRE:

    $ fire niv udtræk-revision flaf RDIO
    Punkt: K-63-00909
    Skriver: {'Revision'}
    Til filen 'flaf-revision.xlsx'
    Overskriver fanebladene {'Revision'}
    med opdaterede versioner.
    Foregående versioner beholdes i 'ex'-filen 'flaf-revision-ex.xlsx'
    Færdig!

Minor-version er højere i fil end i installeret version. Advarsel fra FIRE, som i de fleste tilfælde vil kunne ignoreres:

    $ fire niv udtræk-revision flaf RDIO
    ADVARSEL: 'flaf' er oprettet med version 1.6.1 - du har version 1.5.3 installeret!
    Punkt: K-63-00909
    Skriver: {'Revision'}
    Til filen 'flaf-revision.xlsx'
    Overskriver fanebladene {'Revision'}
        med opdaterede versioner.
    Foregående versioner beholdes i 'ex'-filen 'flaf-revision-ex.xlsx'
    Færdig!

Major-version er forskellig mellem fil og installeret version udløser fejl og programmet afbrydes. Vi må forvente der er breaking changes.

    $ fire niv udtræk-revision flaf RDIO
    FEJL: 'flaf' er oprettet med version 1.5.3 - du har version 2.6.1 installeret!