### PR TITLE
Forbedringer af `fire niv udtræk-observationer`

### DIFF
--- a/fire/api/firedb/hent.py
+++ b/fire/api/firedb/hent.py
@@ -214,6 +214,7 @@ class FireDbHent(FireDbBase):
         srid: Srid = None,
         kun_aktive: bool = True,
         observationsklasse: Observation = Observation,
+        sigtepunkter: List[Punkt] = None,
     ) -> List[Observation]:
         """
         Hent observationer, hvor `punkt` var opstillingspunktet.
@@ -229,6 +230,10 @@ class FireDbHent(FireDbBase):
 
         if kun_aktive:
             filtre.append(observationsklasse._registreringtil == None)
+
+        if sigtepunkter is not None:
+            sigtepunktider = [sigtepunkt.id for sigtepunkt in sigtepunkter]
+            filtre.append(observationsklasse.sigtepunktid.in_(sigtepunktider))
 
         query = self.session.query(observationsklasse)
 

--- a/fire/api/niv/udtræk_observationer.py
+++ b/fire/api/niv/udtræk_observationer.py
@@ -132,7 +132,7 @@ def punkter_til_geojson(data: pd.DataFrame) -> dict:
         "features": [
             {
                 "type": "Feature",
-                "properties": {k: v for k, v in row.iteritems()},
+                "properties": {k: v for k, v in row.items()},
                 "geometry": {
                     "type": "Point",
                     "coordinates": row[["Øst", "Nord"]].tolist(),

--- a/fire/cli/niv/_udtræk_observationer.py
+++ b/fire/cli/niv/_udtræk_observationer.py
@@ -307,6 +307,9 @@ def udtræk_observationer(
         )
         resultatsæt |= set(brug_alle_på_alle(søgefunktioner, klargjorte_geometrier))
 
+    if not resultatsæt:
+        raise SystemExit("Ingen observationer fundet")
+
     # Anvend kvalitetskriterier
     # -------------------------
 

--- a/fire/cli/niv/_udtræk_observationer.py
+++ b/fire/cli/niv/_udtræk_observationer.py
@@ -148,6 +148,13 @@ Er metode ikke angivet, søger programmet blandt begge observationstyper.
     required=False,
     type=Datetime(format=DATE_FORMAT),
 )
+@click.option(
+    "-ao",
+    "--alle-obs",
+    help="Hent alle observationer til de adspurgte punkter.",
+    required=False,
+    is_flag=True,
+)
 @fire.cli.default_options()
 def udtræk_observationer(
     projektnavn: str,
@@ -157,6 +164,7 @@ def udtræk_observationer(
     metode: str,
     fra: dt.datetime,
     til: dt.datetime,
+    alle_obs: bool,
     # These `kwargs` can be ignored for now, since they refer to default
     # CLI options that are already in effect by use of call-back functions.
     **kwargs,
@@ -198,6 +206,10 @@ def udtræk_observationer(
 
         Se de enkelte kommando-linie-argumenters dokumentation for flere
         detaljer om deres betydning for fremsøgningsprocessen.
+
+        Ved angivelse af identer i KRITERIER fremsøges kun observationer
+        mellem de adspurgte punkter. Ønskes alle observationer til de
+        adspurgte punkter kan `--alle-obs` tilføjes kaldet.
 
     Geometrifiler:
 
@@ -249,8 +261,17 @@ def udtræk_observationer(
             DVR90 = db.hent_srid(SRID.DVR90)
             funktion = db.hent_observationer_fra_opstillingspunkt
             fastholdte_argumenter = dict(
-                tid_fra=fra, tid_til=til, srid=DVR90, kun_aktive=True
+                tid_fra=fra,
+                tid_til=til,
+                srid=DVR90,
+                kun_aktive=True,
+                sigtepunkter=punkter,
             )
+
+            if alle_obs:
+                # Når ingen sigtepunkter angives hentes alle observationer til opstillingspunktet
+                fastholdte_argumenter.pop("sigtepunkter")
+
             forberedt_søgefunktion = partial(funktion, **fastholdte_argumenter)
 
         else:  # Buffer > 0

--- a/fire/cli/niv/_udtræk_observationer.py
+++ b/fire/cli/niv/_udtræk_observationer.py
@@ -137,14 +137,14 @@ Er metode ikke angivet, søger programmet blandt begge observationstyper.
 @click.option(
     "-df",
     "--fra",
-    help="Hent observationer fra og med denne dato.",
+    help=f"Hent observationer fra og med denne dato. Angives på formen {DATE_FORMAT}.",
     required=False,
     type=Datetime(format=DATE_FORMAT),
 )
 @click.option(
     "-dt",
     "--til",
-    help="Hent observationer til, men ikke med, denne dato.",
+    help="Hent observationer til, men ikke med, denne dato. Angives på formen {DATE_FORMAT}.",
     required=False,
     type=Datetime(format=DATE_FORMAT),
 )


### PR DESCRIPTION
Primær forskel er ændring i fremsøgningsmekanismen, hvor der som udgangspunkt nu kun findes observationer mellem de punkter der spørges efter. De gamle funktionalitet kan opnås ved at tilføje `--alle-obs`.

Derudover er nogle småting rettet, især deprecation warnings fra pandas.