### PR TITLE
Ret fejl i NEU-tidsseriekomponenter

### DIFF
--- a/fire/api/model/tidsserier.py
+++ b/fire/api/model/tidsserier.py
@@ -122,7 +122,7 @@ class GNSSTidsserie(Tidsserie):
     @functools.cached_property
     def X(self) -> List[float]:
         """
-        Liste med tidsseriens x-værdier normaliseret til tidsseriens første koordinat.
+        Liste med tidsseriens x-værdier normaliseret til tidsseriens første element.
 
         Koordinatkomponenten er i geocentrisk repræsentation.
         """
@@ -141,7 +141,7 @@ class GNSSTidsserie(Tidsserie):
     @functools.cached_property
     def Y(self) -> List[float]:
         """
-        Liste med tidsseriens y-værdier normaliseret til tidsseriens første koordinat.
+        Liste med tidsseriens y-værdier normaliseret til tidsseriens første element.
 
         Koordinatkomponenten er i geocentrisk repræsentation.
         """
@@ -151,7 +151,7 @@ class GNSSTidsserie(Tidsserie):
     @functools.cached_property
     def Z(self) -> List[float]:
         """
-        Liste med tidsseriens z-værdier normaliseret til tidsseriens første koordinat.
+        Liste med tidsseriens z-værdier normaliseret til tidsseriens første element.
 
         Koordinatkomponenten er i geocentrisk repræsentation.
         """
@@ -222,30 +222,30 @@ class GNSSTidsserie(Tidsserie):
         """
         # omtrentlig position, godt nok?
         lon, lat = self.punkt.geometri.koordinater
-        return [xyz2neu(x, y, z, lon, lat) for x, y, z in zip(self.X, self.Y, self.Z)]
+        return [xyz2neu(x, y, z, lat, lon) for x, y, z in zip(self.X, self.Y, self.Z)]
 
     @property
     def n(self):
         """
-        Tidsseriens udvikling i nordlig retning, normaliseret.
+        Tidsseriens udvikling i nordlig retning, normaliseret til tidsseriens
+        første element.
         """
-        lon, lat = self.punkt.geometri.koordinater
         return [n for n, _, _ in self._neu()]
 
     @property
     def e(self):
         """
-        Tidsseriens udvikling i nordlig retning, normaliseret.
+        Tidsseriens udvikling i østlig retning, normaliseret til tidsseriens
+        første element.
         """
-        lon, lat = self.punkt.geometri.koordinater
         return [e for _, e, _ in self._neu()]
 
     @property
     def u(self):
         """
-        Tidsseriens udvikling i nordlig retning, normaliseret.
+        Tidsseriens udvikling i op-retningen, normaliseret til tidsseriens 
+        første element.
         """
-        lon, lat = self.punkt.geometri.koordinater
         return [u for _, _, u in self._neu()]
 
     def _obs_liste(self, observationsklasse: Observation, attribut: str):

--- a/test/test_matematik.py
+++ b/test/test_matematik.py
@@ -5,7 +5,7 @@ import numpy as np
 from fire.matematik import (
     neu2xyz,
     xyz2neu,
-    Rneu_xyz,
+    Rxyz_neu,
 )
 
 W = 0.001**2
@@ -46,12 +46,12 @@ def test_neu2xyz_og_xyz2neu():
     assert isclose(u, U)
 
 
-def test_Rneu_xyz():
+def test_Rxyz_neu():
     """
     Test at rotationsmatrixen kan levere en fejlfri frem- og tilbage rotation.
     """
 
-    R = Rneu_xyz(55.2, 12.2)
+    R = Rxyz_neu(55.2, 12.2)
     cov_neu = R.T @ COV_XYZ @ R
     cov_xyz_return = R @ cov_neu @ R.T
 


### PR DESCRIPTION
To fejl identificeret og rettet:

1. Der var byttet om på længde- og breddegrad funktionskald til dannelse af rotationsmatrix
2. Rotationsmatrix forkert bygget op

Med disse fejl rettet ser de tre komponenter mere korrekte ud i tidsserieplots.

Herunder et sæt før og efter plots til visuel verifikation af ændringerne. Generelt ses en væsentligt pænere nord-komponent og større udsving på up-komponenten. Nord og up er ikke længere (tilsyneladende) korrelerede.

BUDP_5D_IGb08_før:
![BUDP_5D_IGb08_før](https://user-images.githubusercontent.com/13132571/222727975-40aa45dc-38ee-40c2-8715-58a8db492339.png)
BUDP_5D_IGb08_efter
![BUDP_5D_IGb08_efter](https://user-images.githubusercontent.com/13132571/222727983-255e3dbe-45e6-4f34-b572-1ad4a40634e6.png)
SMID_5D_IGb08_før
![SMID_5D_IGb08_før](https://user-images.githubusercontent.com/13132571/222728007-f6eafc2f-65ad-45f0-893d-517e20fc115b.png)
SMID_5D_IGb08_efter
![SMID_5D_IGb08_efter](https://user-images.githubusercontent.com/13132571/222728015-66e6fc86-22e9-4859-b7f6-cb55d36d5007.png)
HABY_5D_IGb08_før
![HABY_5D_IGb08_før](https://user-images.githubusercontent.com/13132571/222728027-0814106c-b87a-440c-a779-2bf7631289c0.png)
HABY_5D_IGb08_efter
![HABY_5D_IGb08_efter](https://user-images.githubusercontent.com/13132571/222728035-e2633df6-f7d7-435e-accd-c2b6b4233747.png)
