### PR TITLE
niv opret-sag: Tydeligør at sag ikke oprettes i DB

### DIFF
--- a/fire/cli/niv/_opret_sag.py
+++ b/fire/cli/niv/_opret_sag.py
@@ -87,10 +87,15 @@ def opret_sag(projektnavn: str, beskrivelse: str, sagsbehandler: str, **kwargs) 
             fire.cli.print(f"Sag '{projektnavn}' oprettet")
         else:
             fire.cli.firedb.session.rollback()
-            fire.cli.print("Opretter IKKE sag")
+            advarsel = click.style(
+            f"BEMÆRK: Sag oprettes IKKE i databasen!",
+            bg="yellow",
+            fg="black",
+            )
+            fire.cli.print(advarsel)
             # Ved demonstration af systemet er det nyttigt at kunne oprette
             # et sagsregneark, uden at oprette en tilhørende sag
-            if not bekræft("Opret sagsregneark alligevel?", gentag=False):
+            if not bekræft("Vil du alligevel oprette et sagsregneark?", gentag=False):
                 return
 
     fire.cli.print(f"Skriver sagsregneark '{projektnavn}.xlsx'")


### PR DESCRIPTION
I tilfælde hvor sag ikke oprettes i databasen (men regneark stadig genereres) er det i nuværende form nemt at overse at sagen ikke er oprettet i databasen. Med denne ændring laves advarselsteksten mere tydeligt, blandt andet ved at skrive den på en gul baggrund.

Før:
![fire_opret_sag_før](https://github.com/SDFIdk/FIRE/assets/13132571/3cb5869e-7664-49e8-8ce4-5ad73cdd3dd6)

Efter:
![fire_opret_sag_efter_gul](https://github.com/SDFIdk/FIRE/assets/13132571/15725842-dff2-4f44-9edc-81aa4afba6a9)
