### PR TITLE
Punkt: Rapporter kun som tabtgået hvis punktinfo er gyldig

### DIFF
--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -262,7 +262,10 @@ class Punkt(FikspunktregisterObjekt):
     @property
     def tabtgået(self) -> bool:
         for punktinfo in self.punktinformationer:
-            if punktinfo.infotype.name == "ATTR:tabtgået":
+            if (
+                punktinfo.infotype.name == "ATTR:tabtgået"
+                and punktinfo.registreringtil is None
+            ):
                 return True
         return False
 


### PR DESCRIPTION
Property Punkt.tabtgået manglede tjek for registreringtil hvilket resulterede i fejlagtige meldinger om tabtgåede punkter når fx `fire niv læs-observationer` afvikles.