### PR TITLE
Opdater mambamiljøer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,12 +62,11 @@ jobs:
 
     - name: Forbered conda environment
       run: |
-        sed -i '/msys2/d' environment-dev.yml
-        sed -i '/m2-zip/d' environment-dev.yml
-        sed -i '/qgis/d' environment-dev.yml
+        sed -i '/bzip2/d' environment-dev.yml
+        cat environment-dev.yml
 
     - name: Cache conda
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # Increase this value to reset cache if environment-dev.yml has not changed
         CACHE_NUMBER: 0
@@ -78,8 +77,10 @@ jobs:
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v2
       with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           environment-file: environment-dev.yml
-          python-version: 3.9
           auto-activate-base: false
           activate-environment: fire-dev
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,30 +1,30 @@
 name: fire-dev
 channels:
   - conda-forge
-  - msys2
 dependencies:
-  - black=22.6.*
-  - click=8.1.*
-  - cx_oracle=8.3.*
-  - fiona=1.8.*
-  - gama=2.*
-  - graphviz=4.0.*
-  - matplotlib=3.*
-  - openpyxl=3.0.*
-  - pandas=1.4.*
-  - pip=22.1.*
-  - pre-commit=2.15.*
-  - pylint=2.14.*
-  - pyproj=3.3.*
-  - pytest-cov=3.0.*
-  - pytest-freezegun=0.4.*
-  - pytest-mock=3.8.*
-  - pytest=7.1.*
-  - python=3.9.*
-  - rich=12.6.*
-  - sphinx-click=4.2.*
-  - sphinx=5.0.*
-  - sphinx_rtd_theme=1.0.*
-  - sphinxcontrib-programoutput=0.16.*
+  - black
+  - click
+  - cx_oracle
+  - fiona
+  - gama
+  - graphviz
+  - matplotlib
+  - numpy
+  - openpyxl
+  - pandas
+  - pip
+  - pre-commit
+  - pylint
+  - pyproj
+  - pytest-cov
+  - pytest-freezegun
+  - pytest-mock
+  - pytest
+  - python=3.11.*
+  - rich
+  - sphinx-click
+  - sphinx
+  - sphinx_rtd_theme
+  - sphinxcontrib-programoutput
   - sqlalchemy=1.4.*
-  - xmltodict=0.13.*
+  - xmltodict

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,14 @@ channels:
 dependencies:
   - click=8.1.*
   - cx_oracle=8.3.*
-  - fiona=1.8.*
+  - fiona=1.9.*
   - gama=2.*
   - openpyxl=3.0.*
   - matplotlib=3.*
-  - pandas=1.4.*
-  - pyproj=3.3.*
-  - python=3.9.*
-  - rich=12.6.*
+  - numpy=1.25.*
+  - pandas=2.0.*
+  - pyproj=3.6.*
+  - python=3.11.*
+  - rich=13.*
   - sqlalchemy=1.4.*
   - xmltodict=0.13.*

--- a/fire/api/firedb/__init__.py
+++ b/fire/api/firedb/__init__.py
@@ -112,7 +112,7 @@ class FireDb(FireDbLuk, FireDbHent, FireDbIndset):
 
         distrikter = self._opmålingsdistrikt_fra_punktid(uuider)
         distrikt_punkter = cs.defaultdict(list)
-        for (distrikt, pktid) in distrikter:
+        for distrikt, pktid in distrikter:
             distrikt_punkter[distrikt].append(pktid)
 
         landsnumre = {}

--- a/fire/api/gama/reader.py
+++ b/fire/api/gama/reader.py
@@ -12,7 +12,6 @@ class GamaReader(object):
         self.input_stream = input_stream
 
     def read(self, sags_id):
-
         sag = self.fireDb.hent_sag(sags_id)
 
         namespace = "{http://www.gnu.org/software/gama/gama-local-adjustment}"

--- a/fire/api/model/geometry.py
+++ b/fire/api/model/geometry.py
@@ -56,7 +56,6 @@ class Geometry(expression.Function):
 
 
 class Point(Geometry):
-
     inherit_cache = True
 
     def __init__(self, p, srid=4326):
@@ -121,7 +120,6 @@ def from_wkt(geom):
     for line in wkt_linestring_match.findall(geom):
         rings = [[]]
         for pair in line.split(","):
-
             if not pair.strip():
                 rings.append([])
                 continue

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -91,7 +91,6 @@ class Artskode(enum.Enum):
 
 
 class FikspunktsType(enum.Enum):
-
     GI = 1
     MV = 2
     HØJDE = 3

--- a/fire/api/model/tidsserier.py
+++ b/fire/api/model/tidsserier.py
@@ -243,7 +243,7 @@ class GNSSTidsserie(Tidsserie):
     @property
     def u(self):
         """
-        Tidsseriens udvikling i op-retningen, normaliseret til tidsseriens 
+        Tidsseriens udvikling i op-retningen, normaliseret til tidsseriens
         første element.
         """
         return [u for _, _, u in self._neu()]

--- a/fire/cli/__init__.py
+++ b/fire/cli/__init__.py
@@ -16,6 +16,7 @@ from fire.api import FireDb
 # spytter exceptionelt meget (irrellevant) output ud ved fejl
 rich.traceback.install(show_locals=True, suppress=[click, sqlalchemy])
 
+
 # Undgå enorme, ubrugelige tracebacks når programmet afbrydes med CTRL+C
 def luk_pænt_ved_ctrl_c(signal, frame):
     raise SystemExit

--- a/fire/cli/indlæs/bernese.py
+++ b/fire/cli/indlæs/bernese.py
@@ -253,7 +253,7 @@ def bernese(
     Indlæs koordinater uden at tilknytte dem til tidsserier::
 
         fire indlæs bernese INGEN ADDNEQ2_2096 COMB2096.CRD COMB2096.COV
-    
+
 
     Indlæs koordinater fra en 5D-beregning med tilhørende tilknytning til
     tidsserier::

--- a/fire/cli/niv/_ilæg_revision.py
+++ b/fire/cli/niv/_ilæg_revision.py
@@ -147,7 +147,7 @@ def udfyld_udeladte_identer(ark: pd.DataFrame) -> pd.DataFrame:
 
     # Udfyld med hvert punkts ident frem ti ldet næste punkt
     udfyldningsværdi = ""
-    for (i, celleværdi_eksisterende) in enumerate(punkter):
+    for i, celleværdi_eksisterende in enumerate(punkter):
         if (trimmet := celleværdi_eksisterende.strip()) != "":
             # Opdatér udfyldningsværdi, så alle felter
             # i samme kolonne får tilskrevet samme
@@ -455,7 +455,7 @@ def ilæg_revision(
     slut_position = revision.index[-1] + 1
     grænser = start_positioner + [slut_position]
     # Slet rækker for ikke-besøgte punkter
-    for (start, stop) in zip(grænser[:-1], grænser[1:]):
+    for start, stop in zip(grænser[:-1], grænser[1:]):
         ikke_besøgt = revision.loc[start]["Ikke besøgt"].strip().lower()
         besøgt = ikke_besøgt != "x"
         if besøgt:

--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -389,7 +389,7 @@ def skriv_gama_inputfil(
 
         # Observationer
         gamafil.write("<height-differences>\n")
-        for (sluk, fra, til, delta_H, L, type, opst, sigma, delta, journal) in zip(
+        for sluk, fra, til, delta_H, L, type, opst, sigma, delta, journal in zip(
             observationer.sluk,
             observationer.fra,
             observationer.til,
@@ -485,7 +485,6 @@ def opdater_arbejdssæt(
     arbejdssæt: Arbejdssæt,
     tg: Timestamp,
 ) -> Arbejdssæt:
-
     for j, (punkt, ny_kote, var) in enumerate(zip(punkter, koter, varianser)):
         if punkt in arbejdssæt.punkt:
             # Hvis punkt findes, sæt indeks til hvor det findes

--- a/fire/cli/niv/_udtræk_observationer.py
+++ b/fire/cli/niv/_udtræk_observationer.py
@@ -239,7 +239,6 @@ def udtræk_observationer(
 
     # Søg baseret på identer
     if identer:
-
         fire.cli.print("Klargør identer", bold=True)
         identer_klargjort: List[str] = klargør_identer_til_søgning(identer)
 

--- a/fire/cli/ts/gnss.py
+++ b/fire/cli/ts/gnss.py
@@ -159,13 +159,13 @@ def gnss(objekt: str, parametre: str, fil: click.Path, **kwargs) -> None:
 
     \b
     **EKSEMPLER**
-    
+
     Vis alle tidsserier for punktet RDIO::
 
         fire ts gnss RDIO
 
     Vis tidsserien 'RDIO_5D_IGb08' med standardparametre::
-    
+
         fire ts gnss RDIO_5D_IGb08
 
     Vis tidsserie med brugerdefinerede parametre::
@@ -287,11 +287,11 @@ def plot_gnss(tidsserie: str, **kwargs) -> None:
         fire ts plot-gnss BUDP_5D_IGB05
 
     Resulterer i visning af nedenstående plot.
-        
+
     .. image:: figures/fire_ts_plot_gnss_BUDP_5D_IGb08.png
         :width: 800
         :alt: Eksempel på plot af 5D-tidsserie for BUDP. Genereret med FIRE v. 1.6.1.
-    
+
     """
     try:
         tidsserie = _find_tidsserie(GNSSTidsserie, tidsserie)

--- a/fire/io/regneark/__init__.py
+++ b/fire/io/regneark/__init__.py
@@ -28,6 +28,7 @@ from fire.api.model import (
 from fire.api.niv.enums import NivMetode
 from fire.srid import SRID
 from fire.io.regneark import arkdef
+import fire.io.dataframe as frame
 from fire.api.model.geometry import (
     normaliser_lokationskoordinat,
 )
@@ -186,7 +187,7 @@ def til_nyt_ark(
     """
     data_dict = (rækkemager(entitet) for entitet in entiteter)
     data_df = pd.DataFrame(data_dict, columns=arkdefinition.keys())
-    ark = nyt_ark(arkdefinition).append(data_df)
+    ark = frame.append_df(nyt_ark(arkdefinition), data_df)
     if sorter_efter is not None:
         return ark.sort_values(sorter_efter)
     return ark

--- a/flame/algorithms/export_observationer_algorithm.py
+++ b/flame/algorithms/export_observationer_algorithm.py
@@ -22,7 +22,6 @@ from qgis.core import (
 
 
 class ExportObservationerAlgorithm(QgsProcessingAlgorithm):
-
     OUTPUT = "OUTPUT"
     INPUT = "INPUT"
     EXPRESSION = "EXPRESSION"

--- a/flame/algorithms/import_observationer_by_location.py
+++ b/flame/algorithms/import_observationer_by_location.py
@@ -46,7 +46,6 @@ import processing
 
 
 class ImportObservationerByLocationAlgorithm(QgsProcessingAlgorithm):
-
     OUTPUT = "OUTPUT"
     INPUT = "INPUT"
     OBSERVATION_TYPE = "OBSERVATION_TYPE"

--- a/flame/settings/settings.py
+++ b/flame/settings/settings.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 class Settings:
     def __init__(self):
-
         RC_NAME = "fire_settings.json"
 
         if os.environ.get("HOME"):

--- a/test/api/niv/test_kriterier.py
+++ b/test/api/niv/test_kriterier.py
@@ -10,7 +10,6 @@ from fire.api.niv.kriterier import (
 
 
 def test_mildeste_kvalitetskrav():
-
     # Genveje
     # Medlemmer
     P, K, D = (Nøjagtighed.P, Nøjagtighed.K, Nøjagtighed.D)

--- a/test/api/niv/test_udtræk_observationer.py
+++ b/test/api/niv/test_udtræk_observationer.py
@@ -36,7 +36,6 @@ from fire.api.niv.udtræk_observationer import (
 
 
 def test_filterkriterier():
-
     # Opsæt og test ét tilfælde
     nøjagtigheder = [Nøjagtighed.P, Nøjagtighed.K, Nøjagtighed.D]
     spredning = filterkriterier(nøjagtigheder)
@@ -141,7 +140,6 @@ def test_brug_alle_på_alle():
 
 
 def test_observationer_inden_for_spredning():
-
     # Observationstype-id
     mgl = ObservationstypeID.geometrisk_koteforskel
     mtl = ObservationstypeID.trigonometrisk_koteforskel
@@ -197,7 +195,6 @@ def test_timestamp_string():
 
 
 def test_punkter_til_geojson(ark_punktoversigt, række_punktoversigt):
-
     # Arrange
     øst = 8.0
     nord = 55.0

--- a/test/cli/test_udtræk_revision.py
+++ b/test/cli/test_udtræk_revision.py
@@ -7,7 +7,6 @@ from fire.cli.niv._udtræk_revision import (
 
 
 def test_lokations_streng():
-
     lokation = (1.11111, 2.2222)
     expected = "2.222 m   1.111 m"
     result = lokationskoordinat_streng(lokation)
@@ -25,7 +24,6 @@ def test_lokations_streng():
 
 
 def test_flyt_attributter_til_toppen():
-
     # Arrange
     @dataclass
     class _type:

--- a/test/gama/test_gama_cli_write.py
+++ b/test/gama/test_gama_cli_write.py
@@ -16,7 +16,7 @@ def _run_cli(runner, title, args, used_files=[]):
         with open(Path(__file__).resolve().parent / filename) as f:
             files.append((filename, f.readlines()))
     with runner.isolated_filesystem():
-        for (filename, data) in files:
+        for filename, data in files:
             with open(filename, "w") as f:
                 f.writelines(data)
 

--- a/test/ident/test_ident_validering.py
+++ b/test/ident/test_ident_validering.py
@@ -30,7 +30,6 @@ def test_kan_være_købstadsnummer():
 
 
 def test_kan_være_gnssid():
-
     eksisterende_gnssider = [
         ["AAAL", "AARH", "AGGR", "ALSL", "ARNM"],
         ["AVER", "BANH", "BEJS", "BISL", "BLAR"],
@@ -61,7 +60,6 @@ def test_kan_være_gnssid():
 
 
 def test_kan_være_gi_nummer():
-
     eksisterende_gi_numre = [
         ["G.M.144", "G.M.144.1", "G.M.143/144", "G.M.1456.1"],
         ["G.M.1499/1500", "G.M.15", "G.M.2", "G.M.35/36.1"],

--- a/test/niv/test_niv.py
+++ b/test/niv/test_niv.py
@@ -77,7 +77,7 @@ def test_observationer(mocker):
 
     with runner.isolated_filesystem():
         # kopier filer til isoleret filsystem
-        for (filename, data) in files:
+        for filename, data in files:
             with open(filename, "w") as f:
                 f.writelines(data)
 

--- a/test/test_bernese.py
+++ b/test/test_bernese.py
@@ -39,7 +39,6 @@ def test_bernesesolution():
     assert reader1.epoke.second == 0
     assert reader1.epoke.microsecond == 0
     assert reader1.datum == "IGb08"
-    assert reader1.__sizeof__() == 640
     assert reader1["MAR6"].dagsresidualer is None
     assert reader1["HERT"].kovarians is None
     assert reader1["HHLM"].flag == "A"
@@ -74,7 +73,6 @@ def test_bernesesolution():
     assert reader2.epoke.second == 0
     assert reader2.epoke.microsecond == 0
     assert reader2.datum == "IGb08"
-    assert reader2.__sizeof__() == 1176
     assert math.isclose(a=float(reader2["MAR6"].dagsresidualer.sn), b=0.12)
     assert math.isclose(a=float(reader2["MAR6"].dagsresidualer.se), b=0.11)
     assert math.isclose(a=float(reader2["MAR6"].dagsresidualer.su), b=0.36)
@@ -110,7 +108,6 @@ def test_bernesesolution():
     assert reader3.epoke.day == 11
     assert reader3.epoke.second == 0
     assert reader3.epoke.microsecond == 0
-    assert reader3.__sizeof__() == 1176
     assert reader3.datum == "IGS14"
     assert reader3["RIKO"].obsstart.year == 2020
     assert reader3["RIKO"].obsstart.month == 3

--- a/test/test_koordinat.py
+++ b/test/test_koordinat.py
@@ -116,7 +116,6 @@ def test_fejlmeld_koordinat_enlig_koordinat(
 def test_fejlmeld_koordinat_sidste_koordinat_i_tidsserie(
     firedb: FireDb, sag: Sag, punkt: Punkt, srid: Srid
 ):
-
     for i in range(2):
         se = Sagsevent(
             id=str(uuid.uuid4()), sag=sag, eventtype=EventType.KOORDINAT_BEREGNET
@@ -153,7 +152,6 @@ def test_fejlmeld_koordinat_sidste_koordinat_i_tidsserie(
 def test_fejlmeld_koordinat_midt_i_tidsserie(
     firedb: FireDb, sag: Sag, punkt: Punkt, srid: Srid
 ):
-
     koordinater = []
     for i in range(3):
         se = Sagsevent(

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -153,7 +153,6 @@ def test_ident(firedb: FireDb, punkt: Punkt):
 
 
 def test_identer(firedb: FireDb):
-
     punkt = firedb.hent_punkt("8e5e57f8-d3c4-45f2-a2a9-492f52d7df1c")
 
     assert "SKEJ" in punkt.identer

--- a/test/test_punktsamling.py
+++ b/test/test_punktsamling.py
@@ -91,7 +91,6 @@ def test_udvid_punktsamling(firedb, sagseventfabrik, punktsamling, punkt):
 
 
 def test_luk_punktsamling(firedb, sagsevent, punktsamling):
-
     firedb.session.flush()
 
     assert punktsamling.sagseventtilid is None

--- a/test/test_sag.py
+++ b/test/test_sag.py
@@ -47,7 +47,6 @@ def test_indset_sagsevent(firedb: FireDb, sag: Sag):
 
 
 def test_indset_sagsevent_materiale(firedb: FireDb, sag: Sag):
-
     blob = os.urandom(1000)
 
     sagseventinfo = SagseventInfo(

--- a/test/test_tidsserie.py
+++ b/test/test_tidsserie.py
@@ -72,7 +72,6 @@ def test_udvid_tidsserie(firedb, højdetidsserie, koordinat):
 
 
 def test_hent_tidsserie_fra_punkt(firedb):
-
     punkt = firedb.hent_punkt("K-63-19113")
     assert len(punkt.tidsserier) == 1
     assert len(punkt.tidsserier[0].koordinater) == 4

--- a/test/test_typologi.py
+++ b/test/test_typologi.py
@@ -33,7 +33,6 @@ def test_adskil_filnavne(tmp_path, identer_gyldige, identer_ugyldige):
 
 
 def test_adskil_identer(identer_gyldige, identer_ugyldige):
-
     gyldige = identer_gyldige
     ugyldige = identer_ugyldige
 


### PR DESCRIPTION
Grundet udfordringer med at resolve udviklingsmiljøet på GitHub Actions
er de fleste pakker i environment-dev.yml sat fri mht versionsnumre.
Udvalgte pakker låses fast til en specifik version, fx SQLAlchemy og
Python. Sidstnævnte opgraderes fra 3.9 til 3.11.

På både Windows og Linux maskiner lykkes det generelt primært at resolve
de nyeste versioner af de pakker der bruges i udviklingsmiljøet. Den
væsentligste undtagelse er sphinx, der grundet opstrømsproblemer ikke
kan opdateres til nyere version end 5.3. Det konkrete problem findes i
en afhængighed til readthedocs temaet. Forhåbentligt løses det snart,
ellers bør det overvejes at skifte til et andet tema så Sphinx og dets
forudsætninger kan benyttes i deres nyeste versioner.

I produktionsmiljøet er versioner af de fleste brugte pakker
pinned til seneste minor version release.

Black er kørt på hele kodebasen med version 23 og formatering opdateret
hvor nødvendigt. Ligeledes er enkelte kodetilpasninger udført for fx ikke
at komme i problemer med Pandas 2.0.