### PR TITLE
FireDb.indset_sag: Undlad exception hvis sag er tilføjet session

### DIFF
--- a/fire/api/firedb/indset.py
+++ b/fire/api/firedb/indset.py
@@ -18,13 +18,13 @@ from fire.api.model import (
 
 class FireDbIndset(FireDbBase):
     def indset_sag(self, sag: Sag, commit: bool = True):
-        if not self._is_new_object(sag):
-            raise Exception(f"Sag allerede tilføjet databasen: {sag}")
         if len(sag.sagsinfos) < 1:
             raise Exception("Mindst et SagsInfo objekt skal tilføjes Sagen")
         if sag.sagsinfos[-1].aktiv != "true":
             raise Exception("Sidst SagsInfo på sagen skal have aktiv = 'true'")
-        self.session.add(sag)
+        
+        if self._is_new_object(sag):
+            self.session.add(sag)
 
         if commit:
             self.session.commit()

--- a/test/test_sag.py
+++ b/test/test_sag.py
@@ -240,3 +240,16 @@ def test_ny_sagsevent_slettede(firedb: FireDb, sag: Sag, koordinatfabrik: Callab
 
     for i in range(5):
         assert koordinater[i].registreringtil is not None
+
+def test_indset_ny_sag(firedb: FireDb):
+    """
+    Test samspil mellem FireDb.ny_sag og FireDb.indset_sag.
+
+    Test specifikt tilføjet i forbindelse med fix af en bug i indset_sag(),
+    der resulterede i en exception ved nedenstående kombination af ny_sag()
+    og indset_sag(), hvilket åbenlyst ikke er hensigtsmæssigt.
+    """
+    sag = firedb.ny_sag(behandler="test", beskrivelse="Bare en test")
+    firedb.indset_sag(sag)
+
+    


### PR DESCRIPTION
Der er lidt cirkulær logik i samspillet mellem `FireDb.ny_sag` og `FireDb.indset_sag`. I førstnævnte er det fordelagtigt at den nyoprettede sag tilføjes den aktive session. Ligeledes er det praktisk/nødvendigt at `FireDb.indset_sat` sikrer sig at sagen er tilføjet sessionen. Nu gøres det uden at trigge en exception hvis sagen allerede er tilføjet.

Før dette fix fejler testen `test_indset_ny_sag`.