### PR TITLE
Håndter fastholdte punkter korrekt i geojson-filer i forbindelse med beregning

### DIFF
--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import math
 import os
 import os.path
 from pathlib import Path
@@ -381,7 +382,7 @@ def punkt_feature(punkter: pd.DataFrame) -> Dict[str, str]:
     """Omsæt punktinformationer til JSON-egnet dict"""
     for i in range(punkter.shape[0]):
         # Fastholdte punkter har ingen ny kote, så vi viser den gamle
-        if punkter.at[i, "Ny kote"] is None:
+        if math.isnan(punkter.at[i, "Ny kote"]) or punkter.at[i, "Ny kote"] is None:
             fastholdt = True
             delta = 0.0
             kote = float(punkter.at[i, "Kote"])


### PR DESCRIPTION
Rækker i regnearket hvor punkter er fastholdte kan efter ændringer i numpy resulterer i at "Ny kote" indeholder NaN i stedet for None. Det resulterer i at alle punkter fremstår om ikke-fastholdte i geojson-outputtet. Ligeledes er alle talværdier i rækkerne sat til nan, hvilket ikke er korrekt.

Dette tages der nu højde for i punkt_feature() hvor der er indført et check for nan.

skriv_punkter_geojson() er også i brug i forbindelse med læsning af observationer, og der genereres input til funktionen lidt anderledes. Derfor er checkes der stadig for None. Det står i skrivende stund uklart om det stadig er aktuelt, men vi beholder både livrem og seler på for en sikkerheds skyld.