### PR TITLE
Fejlmelding af koordinater

### DIFF
--- a/docs/apps/luk.rst
+++ b/docs/apps/luk.rst
@@ -9,3 +9,7 @@ typer objekter i databasen.
 .. click:: fire.cli.luk:punkt
   :prog: fire luk punkt
   :show-nested:
+
+.. click:: fire.cli.luk:koordinat
+  :prog: fire luk koordinat
+  :show-nested:

--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -158,7 +158,8 @@ def koordinatrapport(
             continue
         if koord.registreringtil is not None:
             if alle or (ts and tskoord) or historik:
-                fire.cli.print(". " + koordinat_linje(koord), fg="red")
+                markør = "X" if koord.fejlmeldt else "."
+                fire.cli.print(f"{markør} " + koordinat_linje(koord), fg="red")
         else:
             fire.cli.print("* " + koordinat_linje(koord), fg="green")
     fire.cli.print("")

--- a/test/test_koordinat.py
+++ b/test/test_koordinat.py
@@ -106,7 +106,7 @@ def test_fejlmeld_koordinat_enlig_koordinat(
     firedb.session.commit()
 
     firedb.fejlmeld_koordinat(
-        Sagsevent(eventtype=EventType.KOORDINAT_BEREGNET, sag=sag), koordinat
+        koordinat, Sagsevent(eventtype=EventType.KOORDINAT_BEREGNET, sag=sag), 
     )
 
     assert koordinat.fejlmeldt is True
@@ -140,7 +140,7 @@ def test_fejlmeld_koordinat_sidste_koordinat_i_tidsserie(
     firedb.session.commit()
 
     firedb.fejlmeld_koordinat(
-        Sagsevent(sag=sag, eventtype=EventType.KOORDINAT_NEDLAGT), koordinat
+        koordinat, Sagsevent(sag=sag, eventtype=EventType.KOORDINAT_NEDLAGT)
     )
 
     assert koordinat.fejlmeldt is True
@@ -178,7 +178,7 @@ def test_fejlmeld_koordinat_midt_i_tidsserie(
     firedb.session.commit()
 
     firedb.fejlmeld_koordinat(
-        Sagsevent(sag=sag, eventtype=EventType.KOORDINAT_NEDLAGT), koordinater[1]
+        koordinater[1], Sagsevent(sag=sag, eventtype=EventType.KOORDINAT_NEDLAGT)
     )
 
     assert koordinater[1].fejlmeldt is True
@@ -220,7 +220,7 @@ def test_fejlmeld_koordinat_midt_i_tidsserie_flere_srider(
     firedb.session.commit()
 
     firedb.fejlmeld_koordinat(
-        Sagsevent(sag=sag, eventtype=EventType.KOORDINAT_NEDLAGT), koordinater[3]
+        koordinater[3], Sagsevent(sag=sag, eventtype=EventType.KOORDINAT_NEDLAGT)
     )
 
     assert koordinater[3].fejlmeldt is True


### PR DESCRIPTION
Tilpasning af `FireDb.fejlmeld_koordinat()` så den virker i alle mulige scenarier. Ny CLI funktion `fire luk koordinat` tilføjet for at kunne lukke/fejlmelde koordinater der er forkert eller fejlindsatte. En lille konsekvensrettelser i `fire info punkt` gør at disse fejlmeldte koordinater for et "X" som markør i outputtet fra funktionen (se eksempel i commit messages).