### PR TITLE
Opdater mamba miljøer

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - numpy
   - openpyxl
   - pandas
+  - pyarrow
   - pip
   - pre-commit
   - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,11 @@ dependencies:
   - cx_oracle=8.3.*
   - fiona=1.9.*
   - gama=2.*
-  - openpyxl=3.0.*
+  - openpyxl=3.1.*
   - matplotlib=3.*
-  - numpy=1.25.*
-  - pandas=2.0.*
+  - numpy=1.26.*
+  - pyarrow=15.*
+  - pandas=2.2.*
   - pyproj=3.6.*
   - python=3.11.*
   - rich=13.*


### PR DESCRIPTION
Pandas 2.2 er begyndt at smide en DeprecationWarning, der advarer om at pyarrow bliver en hård afhængighed fra pandas 3.0. For at lukke munden på pandas (og tillade at testsuiten afvikles) tilføjes pyarrow. Ligeledes opdateres enkelte pakker til nyere version.