### PR TITLE
Opdater views

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -240,8 +240,8 @@ VALUES
     'V_CORS_DK',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -314,8 +314,8 @@ VALUES
     'V_TAPAS',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -388,8 +388,8 @@ VALUES
     'V_5D_PUNKTER',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -463,8 +463,8 @@ VALUES
     'V_10KM_PUNKTER',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -538,8 +538,8 @@ VALUES
     'V_DMI_VANDSTANDSMAALERE',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -612,8 +612,8 @@ VALUES
     'V_DVR90_VANDSTANDSMAALERE',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -693,8 +693,8 @@ VALUES
     'V_GPSNET',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -775,8 +775,8 @@ VALUES
     'V_SMARTNET',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -856,8 +856,8 @@ VALUES
     'V_RTKCONNECT',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -905,8 +905,8 @@ VALUES
     'V_TABTE_PUNKTER',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -1007,8 +1007,8 @@ VALUES
     'V_PRES3_OBS',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -1050,8 +1050,8 @@ VALUES
     'V_PRES2_OBS',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );
@@ -1093,8 +1093,8 @@ VALUES
     'V_PRES1_OBS',
     'GEOMETRI',
     MDSYS.SDO_DIM_ARRAY(
-      MDSYS.SDO_DIM_ELEMENT('Longitude', -180.0000, 180.0000, 0.005),
-      MDSYS.SDO_DIM_ELEMENT('Latitude', -90.0000, 90.0000, 0.005)
+      MDSYS.SDO_DIM_ELEMENT('Longitude', 7.0, 16.0, 0.005),
+      MDSYS.SDO_DIM_ELEMENT('Latitude', 54.0000, 59.0000, 0.005)
     ),
     4326
   );

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -216,8 +216,8 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,
@@ -290,8 +290,8 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,
@@ -364,8 +364,8 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,
@@ -439,8 +439,8 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -641,6 +641,11 @@ WITH
 		JOIN punktinfotype pit ON pi.infotypeid=pit.infotypeid
 		WHERE pit.infotype='IDENT:landsnr' AND pi.registreringtil IS NULL
 	),
+	ekstern_ident AS (
+		SELECT pi.punktid, pi.tekst ident FROM punktinfo pi
+		JOIN punktinfotype pit ON pi.infotypeid=pit.infotypeid
+		WHERE pit.infotype='IDENT:ekstern' AND pi.registreringtil IS NULL
+	),
 	etrs89 AS (
 		SELECT k.punktid,k.t,k.x,k.y,k.z FROM koordinat k
 		JOIN sridtype st ON k.sridid=st.sridid
@@ -662,8 +667,9 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
+	ekstern_ident.ident EKSTERN_IDENT,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,
@@ -673,6 +679,7 @@ SELECT
 FROM punkter
 LEFT JOIN gnss_ident ON punkter.punktid=gnss_ident.punktid
 LEFT JOIN landsnr ON punkter.punktid=landsnr.punktid
+LEFT JOIN ekstern_ident ON punkter.punktid=ekstern_ident.punktid
 LEFT JOIN etrs89 ON punkter.punktid=etrs89.punktid
 LEFT JOIN dvr90 ON punkter.punktid=dvr90.punktid
 LEFT JOIN tabtgaaet ON punkter.punktid=tabtgaaet.punktid
@@ -716,6 +723,11 @@ WITH
 		JOIN punktinfotype pit ON pi.infotypeid=pit.infotypeid
 		WHERE pit.infotype='IDENT:landsnr' AND pi.registreringtil IS NULL
 	),
+	ekstern_ident AS (
+		SELECT pi.punktid, pi.tekst ident FROM punktinfo pi
+		JOIN punktinfotype pit ON pi.infotypeid=pit.infotypeid
+		WHERE pit.infotype='IDENT:ekstern' AND pi.registreringtil IS NULL
+	),
 	etrs89 AS (
 		SELECT k.punktid,k.t,k.x,k.y,k.z FROM koordinat k
 		JOIN sridtype st ON k.sridid=st.sridid
@@ -737,8 +749,9 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
+	ekstern_ident.ident EKSTERN_IDENT,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,
@@ -748,6 +761,7 @@ SELECT
 FROM punkter
 LEFT JOIN gnss_ident ON punkter.punktid=gnss_ident.punktid
 LEFT JOIN landsnr ON punkter.punktid=landsnr.punktid
+LEFT JOIN ekstern_ident ON punkter.punktid=ekstern_ident.punktid
 LEFT JOIN etrs89 ON punkter.punktid=etrs89.punktid
 LEFT JOIN dvr90 ON punkter.punktid=dvr90.punktid
 LEFT JOIN tabtgaaet ON punkter.punktid=tabtgaaet.punktid
@@ -790,6 +804,11 @@ WITH
 		JOIN punktinfotype pit ON pi.infotypeid=pit.infotypeid
 		WHERE pit.infotype='IDENT:landsnr' AND pi.registreringtil IS NULL
 	),
+	ekstern_ident AS (
+		SELECT pi.punktid, pi.tekst ident FROM punktinfo pi
+		JOIN punktinfotype pit ON pi.infotypeid=pit.infotypeid
+		WHERE pit.infotype='IDENT:ekstern' AND pi.registreringtil IS NULL
+	),
 	etrs89 AS (
 		SELECT k.punktid,k.t,k.x,k.y,k.z FROM koordinat k
 		JOIN sridtype st ON k.sridid=st.sridid
@@ -811,8 +830,9 @@ WITH
 	)
 SELECT
 	geometrier.geometri,
-	landsnr.ident LANDSNR,
 	gnss_ident.ident GNSS_NAVN,
+	landsnr.ident LANDSNR,
+	ekstern_ident.ident EKSTERN_IDENT,
 	etrs89.t  ETRS89_T,
 	etrs89.x  ETRS89_LON,
 	etrs89.y  ETRS89_LAT,
@@ -822,6 +842,7 @@ SELECT
 FROM punkter
 LEFT JOIN gnss_ident ON punkter.punktid=gnss_ident.punktid
 LEFT JOIN landsnr ON punkter.punktid=landsnr.punktid
+LEFT JOIN ekstern_ident ON punkter.punktid=ekstern_ident.punktid
 LEFT JOIN etrs89 ON punkter.punktid=etrs89.punktid
 LEFT JOIN dvr90 ON punkter.punktid=dvr90.punktid
 LEFT JOIN tabtgaaet ON punkter.punktid=tabtgaaet.punktid


### PR DESCRIPTION
Følgende ændringer foretaget:

1. IDENT:ekstern tilføjet som attribut på views over RTK-tjenesternes stationer
2. IDEN:GNSS sat som første attribut i lagene, så labels kan sættes nemt i QGIS (højreklik på lag, "vis labels")
3. Bounding boxes er tilpasset Danmark for alle views pånær det med GNET