### PR TITLE
Forfin sortering af koordinatliste fra fire info punkt

### DIFF
--- a/fire/cli/info.py
+++ b/fire/cli/info.py
@@ -147,9 +147,17 @@ def koordinatrapport(
     """
     Hjælpefunktion for 'punkt_fuld_rapport': Udskriv formateret koordinatliste
     """
+    # Sorter efter SRID, koordinattidsspunkt og registreringfra. Sidstnævnte er relevant i særlige
+    # tilfælde hvor to identiske Koordinater findes i databasen, hvoraf den ene er fejlmeldt. Se
+    # fx 24-09-09091 i februar 2024. De to identiske koter skyldes at 2020-koten ved en fejl ikke var
+    # blevet indlæst i 2020 og derfor blev indsat på bagkant i 2024 med det resultat at den stod som
+    # gældende kote i stedet for den nye 2024-kote. Ved at fejlmelde den først indlæste 2024-kote var
+    # det muligt at indsætte samme kote fra 2024 igen og dermed lade den være den gældende.
     koordinater.sort(
-        key=lambda x: (x.srid.name, x.t.strftime("%Y-%m-%dT%H:%M")), reverse=True
+        key=lambda x: (x.srid.name, x.t.strftime("%Y-%m-%dT%H:%M"), x.registreringfra),
+        reverse=True,
     )
+
     ts = True if "ts" in options.split(",") else False
     alle = True if "alle" in options.split(",") else False
     for koord in koordinater:


### PR DESCRIPTION
I særlige tilfælde kan det ske at den gældende koordinat ikke står øverst i koordinatlisten selvom den åbenlyst burde det. Et eksempel på dette er tilføjet i kommentarerne. Ved at tilføje registreringfra til sorteringsnøglen undgås denne situation.

På billederne herunder ses før og efter situationen. Bemærk rækkefølgen på de to øverste koordinater i listen.

![billede](https://github.com/SDFIdk/FIRE/assets/13132571/104bba5c-fcd5-4a26-9f12-bdc624b53139)

![billede](https://github.com/SDFIdk/FIRE/assets/13132571/d230a515-b633-4105-b47e-e7a41d2ffabe)
