### PR TITLE
Forbedringer af `fire niv udtræk-observationer`

### DIFF
--- a/fire/api/niv/udtræk_observationer.py
+++ b/fire/api/niv/udtræk_observationer.py
@@ -120,16 +120,6 @@ def klargør_geometrifiler(geometrifiler: Iterable[str]) -> List[Geometry]:
     return klargjorte_geometrier
 
 
-def opstillingspunkter(observationer: Iterable[Observation]) -> List[Punkt]:
-    """Returnerer unikke opstillingspunkter for observationerne."""
-    return list(set(o.opstillingspunkt for o in observationer))
-
-
-def sigtepunkter(observationer: Iterable[Observation]) -> List[Punkt]:
-    """Returnerer unikke sigtepunkter for observationerne."""
-    return list(set(o.sigtepunkt for o in observationer))
-
-
 def punkter_til_geojson(data: pd.DataFrame) -> dict:
     """Konvertér punkter til geojson-tekststreng."""
     return {

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -487,6 +487,7 @@ def obs_feature(
                 "Målinger": antal_målinger[tuple(sorted([fra, til]))],
                 "Afstand": observationer.at[i, "L"],
                 "ΔH": observationer.at[i, "ΔH"],
+                "Observationstidspunkt": str(observationer.at[i, "Hvornår"]),
                 # konvertering, da json.dump ikke uderstøtter int64
                 "Opstillinger": int(observationer.at[i, "Opst"]),
                 "Journal": observationer.at[i, "Journal"],

--- a/test/api/niv/test_udtræk_observationer.py
+++ b/test/api/niv/test_udtræk_observationer.py
@@ -29,7 +29,6 @@ from fire.api.niv.udtræk_observationer import (
     søgefunktioner_med_valgte_metoder,
     brug_alle_på_alle,
     observationer_inden_for_spredning,
-    opstillingspunkter,
     timestamp,
     punkter_til_geojson,
 )
@@ -175,14 +174,6 @@ def test_observationer_inden_for_spredning():
 
     result = set(observationer_inden_for_spredning(tks, spredning))
     expected = tks_indenfor
-    assert result == expected, f"Forventede, at {result!r} var {expected!r}."
-
-
-def test_opstillingspunkter():
-    punkter = [Punkt() for _ in range(10)]
-    observationer = [GK(opstillingspunkt=punkt) for punkt in punkter]
-    result = set(opstillingspunkter(observationer))
-    expected = set(punkter)
     assert result == expected, f"Forventede, at {result!r} var {expected!r}."
 
 

--- a/test/test_punkt.py
+++ b/test/test_punkt.py
@@ -82,6 +82,7 @@ def test_hent_punkt(firedb: FireDb, punkt: Punkt):
     s = p.sagsevent
     assert isinstance(s, Sagsevent)
 
+
 def test_hent_punkt(firedb: FireDb):
     """
     Test at `hent_punkt()` returnerer det eksakte match i tilfælde af der
@@ -195,6 +196,33 @@ def test_hent_punkt_liste(firedb: FireDb):
         ["SKEJ", "RDIO", "ukendt_ident"], ignorer_ukendte=True
     )
     assert len(punkter) == 2
+
+
+def test_hent_punkter_fra_uuid_liste(firedb: FireDb):
+
+    identer = ["RDIO", "RDO1", "G.I.1234"]
+
+    punkter = firedb.hent_punkter_fra_uuid_liste(
+        [
+            "301b8578-8cc8-48a8-8446-541f31482f86",  # RDIO
+            "4b4c5c17-32e8-495d-a598-cdf42e0892de",  # RDO1
+            "4871c57b-d325-45fa-a03a-fdcff49273c0",  # G.I.1234
+        ]
+    )
+
+    for punkt in punkter:
+        assert punkt.ident in identer
+
+    # Tjek håndtering af opslag på ikke-eksisterende punkter
+    punkter = firedb.hent_punkter_fra_uuid_liste(
+        [
+            "et-uuid-der-ikke-findes",
+            "et-andet-uuid-der-ikke-findes",
+        ]
+    )
+
+    # Vi forventer en tom liste her
+    assert not punkter
 
 
 def test_soeg_punkter(firedb: FireDb):


### PR DESCRIPTION
Med dette PR tilføjes

1. Muligheden for at se de udtrukne observationer i geojson output
2. Observationstidspunktet tilføjet til ovennævnte geojson output
3. En markant performance forbedring på generering af den afsluttende punktliste (flere minutter skæres af)