### PR TITLE
API ændringer til Punktsamlinger

### DIFF
--- a/fire/api/firedb/hent.py
+++ b/fire/api/firedb/hent.py
@@ -167,6 +167,16 @@ class FireDbHent(FireDbBase):
             .one()
         )
 
+    def hent_alle_punktsamlinger(self) -> list[PunktSamling]:
+        """
+        Hent alle punktsamlinger fra databasen.
+        """
+        return (
+            self.session.query(PunktSamling)
+            .filter(PunktSamling._registreringtil == None)  # NOQA
+            .all()
+        )
+
     def hent_tidsserie(self, navn: str) -> Tidsserie:
         """
         Hent en tidsserie ud fra dens navn.

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -265,35 +265,36 @@ class Punkt(FikspunktregisterObjekt):
                 return True
         return False
 
-    @property
-    def landsnummer(self) -> str:
-        landsnumre = []
+    def _hent_ident_af_type(self, identtype: str) -> str:
+        numre = []
         for punktinfo in self.punktinformationer:
             if (
-                punktinfo.infotype.name == "IDENT:landsnr"
+                punktinfo.infotype.name == identtype
                 and not punktinfo.registreringtil
             ):
-                landsnumre.append(punktinfo.tekst)
+                numre.append(punktinfo.tekst)
 
-        if landsnumre:
-            return sorted(landsnumre)[0]
+        if numre:
+            return sorted(numre)[0]
+
+        return None
+
+    @property
+    def landsnummer(self) -> str:
+        _landsnummer = self._hent_ident_af_type("IDENT:landsnr")
+
+        if _landsnummer:
+            return _landsnummer
 
         return self.ident
 
     @property
     def gnss_navn(self) -> str:
-        gnss_navne = []
-        for punktinfo in self.punktinformationer:
-            if (
-                punktinfo.infotype.name == "IDENT:GNSS"
-                and not punktinfo.registreringtil
-            ):
-                gnss_navne.append(punktinfo.tekst)
+        return self._hent_ident_af_type("IDENT:GNSS")
 
-        if gnss_navne:
-            return sorted(gnss_navne)[0]
-
-        return None
+    @property
+    def jessennummer(self) -> str:
+       return self._hent_ident_af_type("IDENT:jessen")
 
     def __lt__(self, other: Punkt) -> bool:
         return self.landsnummer < other.landsnummer

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -148,6 +148,7 @@ class Punkt(FikspunktregisterObjekt):
     )
     punktsamlinger = relationship(
         "PunktSamling",
+        secondary = punktsamling_punkt,
         order_by="PunktSamling.objektid",
         viewonly=True,
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -116,13 +116,15 @@ def punkt(punktfabrik):
 @pytest.fixture()
 def punktsamling(firedb, sagsevent, punktfabrik, koordinat):
     sagsevent.eventtype = EventType.PUNKTGRUPPE_MODIFICERET
+    jessenpunkt=punktfabrik()
+
     pg = PunktSamling(
         sagsevent=sagsevent,
         navn=f"test-{fire.uuid()[0:9]}",
         formål="Test",
-        jessenpunkt=punktfabrik(),
+        jessenpunkt=jessenpunkt,
         jessenkoordinat=koordinat,
-        punkter=[punktfabrik() for _ in range(5)],
+        punkter=[jessenpunkt,]+[punktfabrik() for _ in range(4)],
     )
     return pg
 

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -1548,6 +1548,7 @@ INSERT INTO punktsamling (
     'Kontrollere stabiliteten af RDIO'
 );
 
+INSERT INTO punktsamling_punkt (punktsamlingsid, punktid) VALUES (1, '301b8578-8cc8-48a8-8446-541f31482f86');
 INSERT INTO punktsamling_punkt (punktsamlingsid, punktid) VALUES (1, 'b54a5515-d050-4049-bcb8-93a5e1039cc3');
 INSERT INTO punktsamling_punkt (punktsamlingsid, punktid) VALUES (1, 'bfe1d698-09fb-450a-81e7-4e2832b6bea7');
 INSERT INTO punktsamling_punkt (punktsamlingsid, punktid) VALUES (1, 'c3d38a21-329e-474a-a4d1-068e8219b622');

--- a/test/test_punktsamling.py
+++ b/test/test_punktsamling.py
@@ -1,16 +1,20 @@
+from typing import Callable
+
 import pytest
 from sqlalchemy.exc import NoResultFound
 
 import fire
 from fire.api import FireDb
 from fire.api.model import (
+    Koordinat,
     Punkt,
     PunktSamling,
+    Sagsevent,
     EventType,
 )
 
 
-def test_hent_punktsamling(firedb):
+def test_hent_punktsamling(firedb: FireDb):
     """Test at vi kan læse punktsamling fra databasen"""
     punktsamling = firedb.hent_punktsamling("Aarhus Nivellementstest")
 
@@ -25,7 +29,12 @@ def test_hent_punktsamling(firedb):
         firedb.hent_punktsamling("findes ikke")
 
 
-def test_hent_fra_punkt(firedb):
+def test_hent_alle_punktsamlinger(firedb: FireDb):
+    p = firedb.hent_alle_punktsamlinger()
+    assert isinstance(p, list)
+
+
+def test_hent_fra_punkt(firedb: FireDb):
     """Test at en punktsamling kan findes via et punkt"""
     punkt = firedb.hent_punkt("RDIO")
     punktsamling = punkt.punktsamlinger[0]
@@ -35,13 +44,17 @@ def test_hent_fra_punkt(firedb):
     assert punktsamling.formål == "Kontrollere stabiliteten af RDIO"
 
 
-def test_opret_punktsamling(firedb, sagsevent, punktfabrik, koordinat):
+def test_opret_punktsamling(
+    firedb: FireDb, sagsevent: Sagsevent, punktfabrik: Callable, koordinat: Koordinat
+):
     """Test at en punktsamling kan oprettes"""
 
     navn = f"Test-{fire.uuid()[0:9]}"
     jessenpunkt = punktfabrik()
 
-    punkter = [jessenpunkt,] + [punktfabrik() for _ in range(3)]
+    punkter = [
+        jessenpunkt,
+    ] + [punktfabrik() for _ in range(3)]
 
     punktsamling = PunktSamling(
         navn=navn,
@@ -69,7 +82,9 @@ def test_opret_punktsamling(firedb, sagsevent, punktfabrik, koordinat):
     assert ps.formål == "Test"
 
 
-def test_udvid_punktsamling(firedb, sagseventfabrik, punktsamling, punkt):
+def test_udvid_punktsamling(
+    firedb: FireDb, sagseventfabrik: Callable, punktsamling: PunktSamling, punkt: Punkt
+):
     """Test at en punktsamling kan oprettes"""
 
     firedb.session.flush()
@@ -90,7 +105,9 @@ def test_udvid_punktsamling(firedb, sagseventfabrik, punktsamling, punkt):
     assert len(punktsamling.punkter) == 6
 
 
-def test_luk_punktsamling(firedb, sagsevent, punktsamling):
+def test_luk_punktsamling(
+    firedb: FireDb, sagsevent: Sagsevent, punktsamling: PunktSamling
+):
     firedb.session.flush()
 
     assert punktsamling.sagseventtilid is None

--- a/test/test_punktsamling.py
+++ b/test/test_punktsamling.py
@@ -17,9 +17,9 @@ def test_hent_punktsamling(firedb):
     assert punktsamling.jessenpunkt.ident == "RDIO"
     assert punktsamling.navn == "Aarhus Nivellementstest"
 
-    assert len(punktsamling.punkter) == 3
+    assert len(punktsamling.punkter) == 4
     for p in punktsamling.punkter:
-        assert p.ident in ("K-63-19113", "K-63-09933", "K-63-09116")
+        assert p.ident in ("RDIO", "K-63-19113", "K-63-09933", "K-63-09116")
 
     with pytest.raises(NoResultFound):
         firedb.hent_punktsamling("findes ikke")
@@ -38,10 +38,10 @@ def test_hent_fra_punkt(firedb):
 def test_opret_punktsamling(firedb, sagsevent, punktfabrik, koordinat):
     """Test at en punktsamling kan oprettes"""
 
-    punkter = [punktfabrik() for _ in range(3)]
-
     navn = f"Test-{fire.uuid()[0:9]}"
     jessenpunkt = punktfabrik()
+
+    punkter = [jessenpunkt,] + [punktfabrik() for _ in range(3)]
 
     punktsamling = PunktSamling(
         navn=navn,


### PR DESCRIPTION
 https://github.com/SDFIdk/FIRE/commit/661211aa3557551245639ccab5d273801d3a5cc3: Tilføjer ny metode til at hente alle punktsamlinger, samt test heraf. 

https://github.com/SDFIdk/FIRE/commit/df6b0a24b10bd5252b70e94b6ed1f1aa0c541e98: Tilføjer ny property på Punkt, som trækker punktets "IDENT:jessen" ud hvis det findes fra Punktinfo. Derudover mindre refaktorisering af lignende properties til lands- og gnss-nummer.

https://github.com/SDFIdk/FIRE/commit/d6f63c49f2df759b7dac5bbc44866b2beee6c042: Ændrer SQLAlchemy mapping mellem Punkt og Punktsamling. Indeholder ingen ændringer på database-niveau. Når man slår op på "Punkt.punktsamlinger" joines nu via tabellen Punktsamling_Punkt i stedet for at gå direkte via Punktsamling.Jessenpunkt.
Dvs at Punkt.punktsamlinger nu opfører sig på samme måde som PunktSamling.punkter, idet de begge bruger "punktsamling_punkt"-tabellen. 
Flg. demonstrerer use-cases før og efter denne commit:

Givet punkt "X":
1. Find alle punktsamlinger hvor "X" indgår:
   - **Før** `ps = [ps for ps in hent_alle_punktsamlinger() if X in ps.punkter]` Den her var ret besværlig.
   - **Efter**  `ps = X.punktsamlinger`

2. Find alle punktsamlinger hvor "X" er Jessenpunkt.
   - **Før**  `ps = X.punktsamlinger`
   - **Efter** ` ps = [ps for ps in X.punktsamlinger if ps.Jessenpunkt==X]`
       - Kan muligvis ændres senere med endnu en attribut på Punkt så man her kan skrive X.Jessenpunktsamlinger el. lign.

