### PR TITLE
Tilføj kolonne "kortnavn" på sridtype

### DIFF
--- a/docs/datamodel.rst
+++ b/docs/datamodel.rst
@@ -217,6 +217,7 @@ tre objekter er bygget op.
                         + objektid : Integer\l
                         + id : Integer\l
                         + SRID: String\l
+                        + kortnavn: String\l
                         + beskrivelse: String\l
                         + x : String\l
                         + y : String\l
@@ -503,7 +504,6 @@ Punktsamlingobjekterne.
                         + punktsamlingsid : Integer\l
                         + navn : String\l
                         + formaal : String\l
-                        + referenceramme : String\l
                         + sridid : Integer
                 }"
             ]

--- a/fire/api/firedb/hent.py
+++ b/fire/api/firedb/hent.py
@@ -368,9 +368,15 @@ class FireDbHent(FireDbBase):
             SRID ikke findes i databasen.
         """
         srid_filter = str(sridid).upper()
-        return (
-            self.session.query(Srid).filter(func.upper(Srid.name) == srid_filter).one()
-        )
+
+        try:
+        # Prøv først at søge på det egentlige srid-navn.
+            srid = self.session.query(Srid).filter(func.upper(Srid.name) == srid_filter).one()
+        except NoResultFound as e:
+        # Ellers søges på sridens korte navn
+            srid = self.session.query(Srid).filter(func.upper(Srid.kortnavn) == srid_filter).one()
+
+        return srid
 
     def hent_srider(self, namespace: Optional[str] = None) -> List[Srid]:
         """

--- a/fire/api/model/punkttyper.py
+++ b/fire/api/model/punkttyper.py
@@ -561,6 +561,7 @@ class Srid(DeclarativeBase):
     objektid = Column(Integer, primary_key=True)
     sridid = Column(Integer, unique=True, nullable=False)
     name = Column("srid", String(36), nullable=False, unique=True)
+    kortnavn = Column("kortnavn", String(36), nullable=True, unique=False)
     beskrivelse = Column(String(4000))
     x = Column(String(4000))
     y = Column(String(4000))

--- a/fire/api/model/tidsserier.py
+++ b/fire/api/model/tidsserier.py
@@ -98,7 +98,6 @@ class Tidsserie(FikspunktregisterObjekt):
     navn = Column(String, nullable=False)
     formål = Column("formaal", String, nullable=False)
 
-    referenceramme = Column(String, nullable=False)
     sridid = Column(Integer, ForeignKey("sridtype.sridid"), nullable=False)
     srid = relationship("Srid", lazy="joined")
 
@@ -116,6 +115,9 @@ class Tidsserie(FikspunktregisterObjekt):
         "polymorphic_on": tstype,
     }
 
+    @property
+    def referenceramme(self):
+        return self.srid.kortnavn
 
 class GNSSTidsserie(Tidsserie):
     __mapper_args__ = {

--- a/fire/cli/indlæs/bernese.py
+++ b/fire/cli/indlæs/bernese.py
@@ -94,7 +94,6 @@ def opret_nye_tidsserier(
                 srid=srid,
                 navn=f"{punkt.gnss_navn}_{tidsserietype}_{solution.datum}",
                 formål=f"GNSS-tidsserie for {punkt.gnss_navn}",
-                referenceramme=f"{solution.datum}",
             )
             nye_tidsserier.append(tidsserie)
 

--- a/fire/cli/ts/gnss.py
+++ b/fire/cli/ts/gnss.py
@@ -735,10 +735,13 @@ def analyse_gnss(
         referenceramme=referenceramme,
     )
 
+    # Hent srid
+    srid = fire.cli.firedb.hent_srid(referenceramme)
+
     # Hent alle tidsserier i FIRE som passer til søgningen
     query = fire.cli.firedb.session.query(GNSSTidsserie).filter(
         GNSSTidsserie._registreringtil == None,
-        GNSSTidsserie.referenceramme == referenceramme,
+        GNSSTidsserie.srid == srid,
     )
 
     # Filtrér på de givne tidsserienavne

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -127,7 +127,6 @@ CREATE TABLE tidsserie (
 
   navn VARCHAR2(4000) NOT NULL UNIQUE,
   formaal VARCHAR2(4000) NOT NULL,
-  referenceramme VARCHAR2(50) NOT NULL,
   sridid INTEGER NOT NULL,
   tstype INTEGER NOT NULL
 );
@@ -856,7 +855,6 @@ COMMENT ON COLUMN tidsserie.sagseventfraid IS 'Angivelse af den hændelse der ha
 COMMENT ON COLUMN tidsserie.sagseventtilid IS 'Angivelse af den hændelse der har bevirket afregistrering af et fikspunktsobjekt';
 COMMENT ON COLUMN tidsserie.navn IS 'Tidsseriens navn';
 COMMENT ON COLUMN tidsserie.formaal IS 'Beskrivelse af formålet med tidsserien.';
-COMMENT ON COLUMN tidsserie.referenceramme IS 'Angivelse af tidsseriens referenceramme, eksempelvis IGS14_REPRO1';
 COMMENT ON COLUMN tidsserie.sridid IS 'Angivelse af transformerbart (så vidt muligt) koordinatsystem for tidsserien. Der findes ikke transformationer til/fra IGS14_REPRO1, det gør der der imod til ITFR2014 hvorfor dette angives som SRID. Transformationsmæssigt er IGS14 og ITRF2014 ækvivalente, så ved at angive ITRF2014 som SRID sikrer vi muligheden for at kunne transformere tidsserien til et andet system.';
 COMMENT ON COLUMN tidsserie.tstype IS 'Angivelse af tidsseriens type. Følgende værdier accepteres, 1: GNSS, 2: Nivellement';
 

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -361,6 +361,7 @@ CREATE TABLE sridtype (
   z VARCHAR2(4000),
   sridid INTEGER NOT NULL,
   srid VARCHAR2(36) NOT NULL,
+  kortnavn VARCHAR2(36) NULL,
   beskrivelse VARCHAR2(4000) NOT NULL
 );
 
@@ -981,6 +982,7 @@ COMMENT ON COLUMN sagsinfo.sagsid IS 'Den sag som sagsinfo holder information fo
 COMMENT ON TABLE sridtype IS 'Udfaldsrum for SRID-koordinatbeskrivelser.';
 COMMENT ON COLUMN sridtype.beskrivelse IS 'Generel beskrivelse af systemet.';
 COMMENT ON COLUMN sridtype.srid IS 'Den egentlige referencesystemindikator.';
+COMMENT ON COLUMN sridtype.kortnavn IS 'Kort og mundret form af sridtype.srid, som kan vises til FIRE-brugere';
 COMMENT ON COLUMN sridtype.sridid IS 'Unik ID i fikspunktsforvaltningssystemet for et et koordinatsystem.';
 COMMENT ON COLUMN sridtype.x IS 'Beskrivelse af x-koordinatens indhold';
 COMMENT ON COLUMN sridtype.y IS 'Beskrivelse af y-koordinatens indhold.';

--- a/test/api/tidsserier/test_analyse_af_tidsserier.py
+++ b/test/api/tidsserier/test_analyse_af_tidsserier.py
@@ -361,7 +361,7 @@ def test_tilføj_tidsserie_i_TidsserieEnsemble(firedb, gnsstidsseriefabrik):
 
 
 def test_tilføj_dårlig_tidsserie_i_TidsserieEnsemble(
-    gnsstidsseriefabrik, højdetidsserie
+    firedb, gnsstidsseriefabrik, højdetidsserie
 ):
     """Test at forsøg på at tilføje dårlige tidsserier afvises."""
     # Opret
@@ -393,7 +393,7 @@ def test_tilføj_dårlig_tidsserie_i_TidsserieEnsemble(
 
     # Tidsserie med forkert referenceramme
     ts3 = gnsstidsseriefabrik()
-    ts3.referenceramme = "FEM"
+    ts3.srid.kortnavn = "FEM"
 
     with pytest.raises(ValueError, match="kunne ikke valideres"):
         ts_ensemble._valider_tidsserie(ts3)
@@ -405,6 +405,7 @@ def test_tilføj_dårlig_tidsserie_i_TidsserieEnsemble(
     ts_ensemble.tilføj_tidsserie(ts3)
     assert len(ts_ensemble.tidsserier) == 0
 
+    firedb.session.rollback()
 
 def test_beregn_samlet_varians_i_TidsserieEnsemble(firedb):
     """Test beregninger af samlet varians for ensemblet."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -169,7 +169,6 @@ def gnsstidsseriefabrik(firedb, sagsevent, punkt, punktsamling, koordinatfabrik,
             punktsamling=punktsamling,
             navn=f"{fire.uuid()}_TEST_FIRE",
             formål="Test",
-            referenceramme="FIRE",
             srid=srid,
             koordinater=[koordinatfabrik() for _ in range(5)],
         )
@@ -196,7 +195,6 @@ def højdetidsseriefabrik(firedb, sagsevent, punkt, punktsamling, koordinatfabri
             punktsamling=punktsamling,
             navn=f"{fire.uuid()}_TEST_FIRE",
             formål="Test",
-            referenceramme="FIRE",
             srid=srid,
             koordinater=[koordinatfabrik() for _ in range(5)],
         )
@@ -270,6 +268,7 @@ def srid(firedb):
             Srid(
                 name="DK:TEST",
                 beskrivelse="SRID til brug i test-suite",
+                kortnavn = "FIRE",
                 x="Easting",
                 y="Northing",
                 z="Højde",

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -63,9 +63,9 @@ INSERT INTO punktinfotype (infotypeid, infotype, anvendelse, beskrivelse) VALUES
 Insert into PUNKTINFOTYPE (INFOTYPEID,INFOTYPE,ANVENDELSE,BESKRIVELSE) values (1,'ATTR:test','FLAG','Testattribut');
 
 -- SELECT x,y,z,sridid, srid, beskrivelse FROM SRIDTYPE WHERE srid='EPSG:5799';
-Insert into SRIDTYPE (X,Y,Z,SRIDID,SRID,BESKRIVELSE) values (null,null,'Kote [m]',8,'EPSG:5799','Kotesystem: Dansk Vertikal Reference 1990');
-Insert into SRIDTYPE (X,Y,Z,SRIDID,SRID,BESKRIVELSE) values ('X [m]','Y [m]','Z [m]',1,'EPSG:9015','Geocentrisk: IGb08');
-Insert into SRIDTYPE (X,Y,Z,SRIDID,SRID,BESKRIVELSE) values ('X [m]','Y [m]','Z [m]',2,'EPSG:8227','Geocentrisk: IGS14');
+Insert into SRIDTYPE (X,Y,Z,SRIDID,SRID,BESKRIVELSE,KORTNAVN) values (null,null,'Kote [m]',8,'EPSG:5799','Kotesystem: Dansk Vertikal Reference 1990', 'DVR90');
+Insert into SRIDTYPE (X,Y,Z,SRIDID,SRID,BESKRIVELSE,KORTNAVN) values ('X [m]','Y [m]','Z [m]',1,'EPSG:9015','Geocentrisk: IGb08', 'IGb08');
+Insert into SRIDTYPE (X,Y,Z,SRIDID,SRID,BESKRIVELSE,KORTNAVN) values ('X [m]','Y [m]','Z [m]',2,'EPSG:8227','Geocentrisk: IGS14', 'IGS14');
 
 
 COMMIT;
@@ -1577,9 +1577,9 @@ INSERT INTO sagseventinfo (
     'sagevent-aaaa-bbbb-0008-000000000002'
 );
 
-INSERT INTO tidsserie (punktid, punktsamlingsid, registreringfra, sagseventfraid, navn, formaal, referenceramme, sridid, tstype) VALUES ('b54a5515-d050-4049-bcb8-93a5e1039cc3', 1, sysdate, 'sagevent-aaaa-bbbb-0008-000000000002', 'HTS_AARHUS_K-63-19113', 'Kontrolmåling af RDIO', 'Lokalt referenceniveau', 8, 2);
-INSERT INTO tidsserie (punktid, punktsamlingsid, registreringfra, sagseventfraid, navn, formaal, referenceramme, sridid, tstype) VALUES ('bfe1d698-09fb-450a-81e7-4e2832b6bea7', 1, sysdate, 'sagevent-aaaa-bbbb-0008-000000000002', 'HTS_AARHUS_K-63-09933', 'Kontrolmåling af RDIO', 'Lokalt referenceniveau', 8, 2);
-INSERT INTO tidsserie (punktid, punktsamlingsid, registreringfra, sagseventfraid, navn, formaal, referenceramme, sridid, tstype) VALUES ('c3d38a21-329e-474a-a4d1-068e8219b622', 1, sysdate, 'sagevent-aaaa-bbbb-0008-000000000002', 'HTS_AARHUS_K-63-09116', 'Kontrolmåling af RDIO', 'Lokalt referenceniveau', 8, 2);
+INSERT INTO tidsserie (punktid, punktsamlingsid, registreringfra, sagseventfraid, navn, formaal, sridid, tstype) VALUES ('b54a5515-d050-4049-bcb8-93a5e1039cc3', 1, sysdate, 'sagevent-aaaa-bbbb-0008-000000000002', 'HTS_AARHUS_K-63-19113', 'Kontrolmåling af RDIO', 8, 2);
+INSERT INTO tidsserie (punktid, punktsamlingsid, registreringfra, sagseventfraid, navn, formaal, sridid, tstype) VALUES ('bfe1d698-09fb-450a-81e7-4e2832b6bea7', 1, sysdate, 'sagevent-aaaa-bbbb-0008-000000000002', 'HTS_AARHUS_K-63-09933', 'Kontrolmåling af RDIO', 8, 2);
+INSERT INTO tidsserie (punktid, punktsamlingsid, registreringfra, sagseventfraid, navn, formaal, sridid, tstype) VALUES ('c3d38a21-329e-474a-a4d1-068e8219b622', 1, sysdate, 'sagevent-aaaa-bbbb-0008-000000000002', 'HTS_AARHUS_K-63-09116', 'Kontrolmåling af RDIO', 8, 2);
 
 -- populer tidsserie_koordinat med tidserier.
 -- Gøres på denne måde da vi ikke kan vide os sikre på objektid'er fra de to tabeller
@@ -1672,8 +1672,8 @@ INSERT INTO sagseventinfo (
     'sagevent-aaaa-bbbb-0008-000000000004'
 );
 
-INSERT INTO tidsserie (punktid, registreringfra, sagseventfraid, navn, formaal, referenceramme, sridid, tstype) VALUES ('301b8578-8cc8-48a8-8446-541f31482f86', sysdate, 'sagevent-aaaa-bbbb-0008-000000000004', 'RDIO_5D_IGb08', '5D-tidsserie for RDIO', 'IGb08', 1, 1);
-INSERT INTO tidsserie (punktid, registreringfra, sagseventfraid, navn, formaal, referenceramme, sridid, tstype) VALUES ('4b4c5c17-32e8-495d-a598-cdf42e0892de', sysdate, 'sagevent-aaaa-bbbb-0008-000000000004', 'RDO1_5D_IGb14', '5D-tidsserie for RDO1', 'IGb14', 2, 1);
+INSERT INTO tidsserie (punktid, registreringfra, sagseventfraid, navn, formaal, sridid, tstype) VALUES ('301b8578-8cc8-48a8-8446-541f31482f86', sysdate, 'sagevent-aaaa-bbbb-0008-000000000004', 'RDIO_5D_IGb08', '5D-tidsserie for RDIO', 1, 1);
+INSERT INTO tidsserie (punktid, registreringfra, sagseventfraid, navn, formaal, sridid, tstype) VALUES ('4b4c5c17-32e8-495d-a598-cdf42e0892de', sysdate, 'sagevent-aaaa-bbbb-0008-000000000004', 'RDO1_5D_IGb14', '5D-tidsserie for RDO1', 2, 1);
 
 
 INSERT INTO tidsserie_koordinat

--- a/test/test_srid.py
+++ b/test/test_srid.py
@@ -1,11 +1,16 @@
 from fire.api.model import Srid
 
 
-def test_hent_srid(firedb):
+def test_hent_srid(firedb, srid):
     # DK:TEST is created by the srid fixture, should be present when this test is run
     key = "DK:TEST"
     srid = firedb.hent_srid(key)
     assert srid.name == key
+
+    kortnavn = "DVR90"
+    srid = firedb.hent_srid(kortnavn)
+    assert srid.name == "EPSG:5799"
+    assert srid.kortnavn == kortnavn
 
 
 def test_indset_srid(firedb):

--- a/test/test_tidsserie.py
+++ b/test/test_tidsserie.py
@@ -21,7 +21,6 @@ def test_opret_tidsserie(firedb, sagsevent, punkt, punktsamling, srid, koordinat
         punktsamling=punktsamling,
         formål="Test",
         navn=f"TS-{fire.uuid()}",
-        referenceramme="FIRE",
         srid=srid,
         koordinater=[koordinatfabrik() for _ in range(5)],
     )
@@ -39,7 +38,6 @@ def test_opret_tidsserie(firedb, sagsevent, punkt, punktsamling, srid, koordinat
         punkt=punkt,
         formål="Test",
         navn=f"TS-{fire.uuid()}",
-        referenceramme="FIRE",
         srid=srid,
         koordinater=[koordinatfabrik() for _ in range(5)],
     )


### PR DESCRIPTION
Skal bruges til diverse brugervendte formål  i stedet for Srid, i tilfælde hvor beskrivelses-feltet er upraktisk. Fx fremsøgning på DVR90, IGb08, Jessen i stedet for hhv. EPSG:5799, EPSG:9015, TS:Jessen,  eller generering af rapporter som vises i terminalen (fx viser fire info punkt et punkts koordinater med angivelse af sriden, hvilket oftest er EPSG-koden. Med denne ændring behøves man ikke at kunne alle EPSG-koderne i hovedet når man får vist en rapport som dén.) 

Derudover indeholder denne PR fjernelsen af feltet "referenceramme" på Tidsserie-tabellen, som tjente samme formål som det nye kortnavn og er derfor redundant. Dog beholdes attributten "referenceramme" i Tidsserie-api'et, der nu henter værdien fra srid.kortnavn 

Denne PR indholder ligesom #768 ændringer på DDL-niveau. Jeg har testet at disse to grene kan merges med hinanden. Der er som allerede nævnt også en lille ændring til Tidsserie-Apiet. Denne kolliderer med #764, men #764 er alligevel i draft-status, så det får jeg rettet op på senere, efter merge af #768 og dette PR.