### PR TITLE
Udelad refgeo id'er fra søgning med FireDb.hent_punkt()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,31 +31,31 @@ jobs:
 
     - name: Installer Oracle instantclient et al
       run: |
-        
+
         mkdir -p /opt/oracle
         cd /opt/oracle
 
         # Download links findes her: https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html
         wget -nv https://download.oracle.com/otn_software/linux/instantclient/2340000/instantclient-basic-linux.x64-23.4.0.24.05.zip
         wget -nv https://download.oracle.com/otn_software/linux/instantclient/2340000/instantclient-sqlplus-linux.x64-23.4.0.24.05.zip
- 
+
         unzip -o instantclient-basic-linux.x64-23.4.0.24.05.zip
         unzip -o instantclient-sqlplus-linux.x64-23.4.0.24.05.zip
 
         ls -la /opt/oracle/instantclient_23_4
 
         sudo apt-get install libaio1
-        
+
         sudo sh -c "echo /opt/oracle/instantclient_23_4 > /etc/ld.so.conf.d/oracle-instantclient.conf"
         sudo ldconfig
 
         export LD_LIBRARY_PATH=/opt/oracle/instantclient_23_4:$LD_LIBRARY_PATH
         export PATH=/opt/oracle/instantclient_23_4:$PATH
-        
+
         # Gem miljøvariable til brug i de følgende trin
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
         echo "PATH=$PATH" >> "$GITHUB_ENV"
-        
+
         which sqlplus
 
     - name: Cache conda
@@ -68,9 +68,8 @@ jobs:
         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment-dev.yml') }}
 
     - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           environment-file: environment-dev.yml

--- a/fire/api/firedb/hent.py
+++ b/fire/api/firedb/hent.py
@@ -106,7 +106,10 @@ class FireDbHent(FireDbBase):
                 .join(PunktInformation)
                 .join(PunktInformationType)
                 .filter(
-                    PunktInformationType.name.startswith("IDENT:"),
+                    and_(
+                        PunktInformationType.name.startswith("IDENT:"),
+                        PunktInformationType.name != "IDENT:refgeo_id",
+                    ),
                     PunktInformation._registreringtil == None,  # NOQA
                     or_(
                         PunktInformation.tekst == ident,
@@ -144,7 +147,8 @@ class FireDbHent(FireDbBase):
                 self.session.query(Punkt)
                 .filter(
                     Punkt.id.in_(subset),
-                ).all()
+                )
+                .all()
             )
 
         return punkter
@@ -370,11 +374,19 @@ class FireDbHent(FireDbBase):
         srid_filter = str(sridid).upper()
 
         try:
-        # Prøv først at søge på det egentlige srid-navn.
-            srid = self.session.query(Srid).filter(func.upper(Srid.name) == srid_filter).one()
+            # Prøv først at søge på det egentlige srid-navn.
+            srid = (
+                self.session.query(Srid)
+                .filter(func.upper(Srid.name) == srid_filter)
+                .one()
+            )
         except NoResultFound as e:
-        # Ellers søges på sridens korte navn
-            srid = self.session.query(Srid).filter(func.upper(Srid.kortnavn) == srid_filter).one()
+            # Ellers søges på sridens korte navn
+            srid = (
+                self.session.query(Srid)
+                .filter(func.upper(Srid.kortnavn) == srid_filter)
+                .one()
+            )
 
         return srid
 


### PR DESCRIPTION
De bliver sjældent brugt, og spænder jævnligt ben for opslag af jessennumre.

Closes #754