### PR TITLE
Punktsamling 4: Tilføj nye niv-underkommandoer til håndtering af punktsamlinger og tidsserie

### DIFF
--- a/fire/cli/luk.py
+++ b/fire/cli/luk.py
@@ -67,16 +67,10 @@ def punkt(uuid: str, sagsbehandler, **kwargs) -> None:
     Se `punkt_hjælp` for yderligere information.
     """
     db = fire.cli.firedb
-    sag = Sag(
-        id=fire.uuid(),
-        sagsinfos=[
-            Sagsinfo(
-                behandler=sagsbehandler,
-                beskrivelse="Lukning af objekt med 'fire luk'",
-                aktiv="true",
-            )
-        ],
-    )
+
+    sag = db.ny_sag(
+        behandler=sagsbehandler, beskrivelse="Lukning af objekt med 'fire luk'"
+        )
     db.session.add(sag)
     db.session.flush()
     sagsevent = Sagsevent(

--- a/fire/cli/luk.py
+++ b/fire/cli/luk.py
@@ -15,6 +15,8 @@ from fire.api.model import (
     EventType,
     Koordinat,
     Observation,
+    PunktSamling,
+    Tidsserie,
 )
 from fire.cli.niv import bekræft
 
@@ -70,7 +72,7 @@ def punkt(uuid: str, sagsbehandler, **kwargs) -> None:
 
     sag = db.ny_sag(
         behandler=sagsbehandler, beskrivelse="Lukning af objekt med 'fire luk'"
-        )
+    )
     db.session.add(sag)
     db.session.flush()
     sagsevent = Sagsevent(
@@ -211,7 +213,7 @@ def observation(objektid: str, sagsbehandler, **kwargs) -> None:
     Fejlmeld en observation i FIRE databasen.
 
     Når en observation fejlmeldes afregistreres den i databasen og
-    det angives samtidigt at observationen ikke er fejlbehæftet.
+    det angives samtidigt at observationen er fejlbehæftet.
 
     Observationens objektid kan fx findes ved opslag med
     ``fire info punkt -O niv <punkt>`` eller ved manuelt opslag i
@@ -273,3 +275,135 @@ def observation(objektid: str, sagsbehandler, **kwargs) -> None:
         else:
             db.session.rollback()
             fire.cli.print(f"Observation {objektid} IKKE lukket!")
+
+
+@luk.command()
+@click.argument("objektid", type=str)
+@click.option(
+    "--sagsbehandler",
+    default=getpass.getuser(),
+    type=str,
+    help="Angiv andet brugernavn end den aktuelt indloggede",
+)
+@fire.cli.default_options()
+def punktsamling(objektid: str, sagsbehandler, **kwargs) -> None:
+    """
+    Luk en punktsamling i FIRE databasen.
+
+    Punktsamlingens objektid skal findes ved manuelt opslag i databasen.
+    Det kan fx gøres med et udtræk som følgende:
+
+    \b
+        SELECT * FROM punktsamling ps
+        WHERE ps.navn = 'PUNKTSAMLING_81001'
+    """
+    db = fire.cli.firedb
+    sag = db.ny_sag(sagsbehandler, beskrivelse="Lukning af punktsamling med 'fire luk'")
+    db.session.add(sag)
+    db.session.flush()
+
+    try:
+        ps = (
+            db.session.query(PunktSamling)
+            .filter(
+                PunktSamling.objektid == objektid,
+            )
+            .one()
+        )
+    except NoResultFound:
+        fire.cli.print(f"Punktsamling med objektid {objektid} ikke fundet!")
+        raise SystemExit
+
+    sagsevent = sag.ny_sagsevent(beskrivelse=f"'fire luk punktsamling {objektid}")
+
+    try:
+        # Indsæt alle objekter i denne session
+        db.luk_punktsamling(ps, sagsevent, commit=False)
+        db.session.flush()
+        db.luk_sag(sag, commit=False)
+        db.session.flush()
+    except DatabaseError as e:
+        # rul tilbage hvis databasen smider en exception
+        db.session.rollback()
+        fire.cli.print(
+            f"Der opstod en fejl - punktsamling med objektid {objektid} IKKE lukket!"
+        )
+        print(e)
+    else:
+        tekst = f"""Er du sikker på at du vil lukke punktsamlingen med {objektid}:
+
+        {repr(ps)}
+"""
+        if bekræft(tekst):
+            db.session.commit()
+            fire.cli.print(f"Punktsamling {objektid} lukket!")
+        else:
+            db.session.rollback()
+            fire.cli.print(f"Punktsamling {objektid} IKKE lukket!")
+
+    return
+
+
+@luk.command()
+@click.argument("objektid", type=str)
+@click.option(
+    "--sagsbehandler",
+    default=getpass.getuser(),
+    type=str,
+    help="Angiv andet brugernavn end den aktuelt indloggede",
+)
+@fire.cli.default_options()
+def tidsserie(objektid: str, sagsbehandler, **kwargs) -> None:
+    """
+    Luk en tidsserie i FIRE databasen.
+
+    Tidsseriens objektid skal findes ved manuelt opslag i databasen.
+    Det kan fx gøres med et udtræk som følgende:
+
+    \b
+        SELECT * FROM tidsserie ts
+        WHERE ts.navn = 'RDIO_5D_IGb08'
+    """
+    db = fire.cli.firedb
+    sag = db.ny_sag(sagsbehandler, beskrivelse="Lukning af tidsserie med 'fire luk'")
+    db.session.add(sag)
+    db.session.flush()
+
+    try:
+        ts = (
+            db.session.query(Tidsserie)
+            .filter(
+                Tidsserie.objektid == objektid,
+            )
+            .one()
+        )
+    except NoResultFound:
+        fire.cli.print(f"Tidsserie med objektid {objektid} ikke fundet!")
+        raise SystemExit
+
+    sagsevent = sag.ny_sagsevent(beskrivelse=f"'fire luk tidsserie {objektid}")
+
+    try:
+        # Indsæt alle objekter i denne session
+        db.luk_tidsserie(ts, sagsevent, commit=False)
+        db.session.flush()
+        db.luk_sag(sag, commit=False)
+        db.session.flush()
+    except DatabaseError as e:
+        # rul tilbage hvis databasen smider en exception
+        db.session.rollback()
+        fire.cli.print(
+            f"Der opstod en fejl - tidsserie med objektid {objektid} IKKE lukket!"
+        )
+        print(e)
+    else:
+        tekst = f"""Er du sikker på at du vil lukke tidsserien med {objektid}:
+
+        {repr(ts)}
+"""
+        if bekræft(tekst):
+            db.session.commit()
+            fire.cli.print(f"Tidsserie {objektid} lukket!")
+        else:
+            db.session.rollback()
+            fire.cli.print(f"Tidsserie {objektid} IKKE lukket!")

--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -25,6 +25,13 @@ import fire.cli
 from fire.cli import firedb, grøn
 
 
+# Kotesystemer som understøttes i niv-modulet
+KOTESYSTEMER = {
+    "DVR90": "EPSG:5799",
+    "Jessen": "TS:jessen",
+    "LRL": "TS:LRL",
+}
+
 # ------------------------------------------------------------------------------
 niv_help = f"""Nivellement: Arbejdsflow, beregning og analyse
 

--- a/fire/cli/niv/_ilæg_nye_punkter.py
+++ b/fire/cli/niv/_ilæg_nye_punkter.py
@@ -195,16 +195,10 @@ def ilæg_nye_punkter(projektnavn: str, sagsbehandler: str, **kwargs) -> None:
 
     # sagsevent for punkter
     er = "er" if len(punkter) > 1 else ""
-    sagsevent_punkter = Sagsevent(
-        sag=sag,
-        eventtype=EventType.PUNKT_OPRETTET,
-        sagseventinfos=[
-            SagseventInfo(
-                beskrivelse=f"Oprettelse af punkt{er} ifm. {projektnavn}",
-            )
-        ],
-        punkter=list(punkter.values()),
-    )
+    sagsevent_punkter = sag.ny_sagsevent(
+        beskrivelse=f"Oprettelse af punkt{er} ifm. {projektnavn}",
+        punkter=list(punkter.values())
+        )
     fire.cli.firedb.indset_sagsevent(sagsevent_punkter, commit=False)
     fire.cli.firedb.session.flush()  # hvis noget ikke virker får vi fejl her!
 
@@ -351,15 +345,9 @@ def ilæg_nye_punkter(projektnavn: str, sagsbehandler: str, **kwargs) -> None:
     punktinfo.extend(landsnumre.values())
 
     # sagsevent for punktinfo
-    sagsevent_punktinfo = Sagsevent(
-        sag=sag,
-        eventtype=EventType.PUNKTINFO_TILFOEJET,
-        sagseventinfos=[
-            SagseventInfo(
-                beskrivelse=f"Oprettelse af punktinfo ifm. {projektnavn}",
-            )
-        ],
-        punktinformationer=punktinfo,
+    sagsevent_punktinfo = sag.ny_sagsevent(
+        beskrivelse=f"Oprettelse af punktinfo ifm. {projektnavn}",
+        punktinformationer=punktinfo
     )
     fire.cli.firedb.indset_sagsevent(sagsevent_punktinfo, commit=False)
     fire.cli.firedb.session.flush()  # hvis noget ikke virker får vi fejl her!

--- a/fire/cli/niv/_læs_observationer.py
+++ b/fire/cli/niv/_læs_observationer.py
@@ -10,7 +10,10 @@ from sqlalchemy.orm.exc import NoResultFound
 from fire.api.model.geometry import (
     normaliser_lokationskoordinat,
 )
-from fire.io.regneark import arkdef
+from fire.io.regneark import (
+    nyt_ark,
+    arkdef,
+)
 import fire.io.dataframe as frame
 import fire.cli
 
@@ -203,7 +206,7 @@ def opbyg_punktoversigt(
     nyetablerede: pd.DataFrame,
     alle_punkter: Tuple[str, ...],
 ) -> pd.DataFrame:
-    punktoversigt = pd.DataFrame(columns=list(arkdef.PUNKTOVERSIGT))
+    punktoversigt = nyt_ark(arkdef.PUNKTOVERSIGT)
     fire.cli.print("Opbygger punktoversigt")
 
     # Forlæng punktoversigt, så der er plads til alle punkter
@@ -293,9 +296,7 @@ def læs_observationsstrenge(
 ) -> pd.DataFrame:
     """Pil observationsstrengene ud fra en række råfiler"""
 
-    observationer = pd.DataFrame(columns=list(arkdef.OBSERVATIONER)).astype(
-        arkdef.OBSERVATIONER
-    )
+    observationer = nyt_ark(arkdef.OBSERVATIONER)
     for fil in filinfo.itertuples(index=False):
         if fil.Type.upper() not in ["MGL", "MTL", "NUL"]:
             continue

--- a/fire/cli/niv/_læs_observationer.py
+++ b/fire/cli/niv/_læs_observationer.py
@@ -24,6 +24,7 @@ from . import (
     skriv_observationer_geojson,
     skriv_ark,
     er_projekt_okay,
+    KOTESYSTEMER,
 )
 
 
@@ -34,7 +35,13 @@ from . import (
     nargs=1,
     type=str,
 )
-def læs_observationer(projektnavn: str, **kwargs) -> None:
+@click.option(
+    "--kotesystem",
+    default="DVR90",
+    type=click.Choice(KOTESYSTEMER.keys()),
+    help="Angiv andet kotesystem end DVR90",
+)
+def læs_observationer(projektnavn: str, kotesystem: str, **kwargs) -> None:
     """Importer data fra observationsfiler og opbyg punktoversigt.
 
     Observationsfiler fra målebilernes instrumenter tilknyttes projektet ved at
@@ -104,7 +111,7 @@ def læs_observationer(projektnavn: str, **kwargs) -> None:
     alle_punkter = nye_punkter + tuple(sorted(gamle_punkter))
 
     # Opbyg oversigt over alle punkter m. kote og lokation
-    punktoversigt = opbyg_punktoversigt(projektnavn, nyetablerede, alle_punkter)
+    punktoversigt = opbyg_punktoversigt(projektnavn, nyetablerede, alle_punkter, kotesystem)
     resultater["Punktoversigt"] = punktoversigt
     skriv_ark(projektnavn, resultater)
     fire.cli.print(
@@ -205,6 +212,7 @@ def opbyg_punktoversigt(
     navn: str,
     nyetablerede: pd.DataFrame,
     alle_punkter: Tuple[str, ...],
+    kotesystem: str = "DVR90",
 ) -> pd.DataFrame:
     punktoversigt = nyt_ark(arkdef.PUNKTOVERSIGT)
     fire.cli.print("Opbygger punktoversigt")
@@ -218,10 +226,10 @@ def opbyg_punktoversigt(
     nye_punkter = tuple(sorted(set(nyetablerede.index)))
 
     try:
-        DVR90 = fire.cli.firedb.hent_srid("EPSG:5799")
-    except KeyError:
+        srid = fire.cli.firedb.hent_srid(KOTESYSTEMER[kotesystem])
+    except NoResultFound:
         fire.cli.print(
-            "DVR90 (EPSG:5799) ikke fundet i srid-tabel", bg="red", fg="white", err=True
+            f"{kotesystem} ({KOTESYSTEMER[kotesystem]}) ikke fundet i srid-tabel", bg="red", fg="white", err=True
         )
         raise SystemExit(1)
 
@@ -237,20 +245,20 @@ def opbyg_punktoversigt(
         # Grav aktuel kote frem
         kote = None
         for koord in pkt.koordinater:
-            if koord.srid != DVR90:
+            if koord.srid != srid:
                 continue
             if koord.registreringtil is None:
                 kote = koord
                 break
 
         punktoversigt.at[punkt, "Fasthold"] = ""
-        punktoversigt.at[punkt, "System"] = "DVR90"
+        punktoversigt.at[punkt, "System"] = kotesystem
         punktoversigt.at[punkt, "uuid"] = ""
         punktoversigt.at[punkt, "Udelad publikation"] = ""
 
         if kote is None:
             fire.cli.print(
-                f"Ingen aktuel DVR90-kote fundet for {punkt}",
+                f"Ingen aktuel {kotesystem}-kote fundet for {punkt}",
                 bg="red",
                 fg="white",
                 err=True,
@@ -273,6 +281,8 @@ def opbyg_punktoversigt(
     for punkt in nye_punkter:
         if pd.isna(punktoversigt.at[punkt, "Kote"]):
             punktoversigt.at[punkt, "Kote"] = None
+        if pd.isna(punktoversigt.at[punkt, "System"]):
+            punktoversigt.at[punkt, "System"] = kotesystem
         if pd.isna(punktoversigt.at[punkt, "Nord"]):
             punktoversigt.at[punkt, "Nord"] = nyetablerede.at[punkt, "Nord"]
         if pd.isna(punktoversigt.at[punkt, "Øst"]):

--- a/fire/cli/niv/_opret_sag.py
+++ b/fire/cli/niv/_opret_sag.py
@@ -6,7 +6,10 @@ import click
 import pandas as pd
 
 from fire import uuid
-from fire.io.regneark import arkdef
+from fire.io.regneark import (
+    nyt_ark,
+    arkdef,
+)
 import fire.cli
 
 from fire.cli.niv import (
@@ -154,11 +157,9 @@ def opret_sag(projektnavn: str, beskrivelse: str, sagsbehandler: str, **kwargs) 
 
     # Dummyopsætninger til sagsregnearkets sider
     forside = pd.DataFrame()
-    nyetablerede = pd.DataFrame(columns=tuple(arkdef.NYETABLEREDE_PUNKTER)).astype(
-        arkdef.NYETABLEREDE_PUNKTER
-    )
+    nyetablerede = nyt_ark(arkdef.NYETABLEREDE_PUNKTER)
     notater = pd.DataFrame([{"Dato": pd.Timestamp.now(), "Hvem": "", "Tekst": ""}])
-    filoversigt = pd.DataFrame(columns=tuple(arkdef.FILOVERSIGT))
+    filoversigt = nyt_ark(arkdef.FILOVERSIGT)
     param = pd.DataFrame(
         columns=["Navn", "Værdi"],
         data=[("Version", fire.__version__), ("Database", fire.cli.firedb.db)],

--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -218,7 +218,8 @@ def regn(projektnavn: str, **kwargs) -> None:
     htmlrapportnavn = gama_udjævn(projektnavn, kontrol)
 
     # Indlæs nødvendige parametre til at skrive Gama output til xlsx
-    punkter, koter, varianser, t_gyldig = læs_gama_output(projektnavn)
+    punkter, koter, varianser = læs_gama_output(projektnavn)
+    t_gyldig = gyldighedstidspunkt(projektnavn)
 
     # Opdater arbejdssæt med GNU Gama output
     beregning = opdater_arbejdssæt(punkter, koter, varianser, arbejdssæt, t_gyldig)
@@ -468,13 +469,13 @@ def læs_gama_output(
     # html-rapportudgaven af beregningsresultatet.
     koteliste = doc["gama-local-adjustment"]["coordinates"]["adjusted"]["point"]
     varliste = doc["gama-local-adjustment"]["coordinates"]["cov-mat"]["flt"]
-    # try:
+
     punkter = [punkt["id"] for punkt in koteliste]
     koter = [float(punkt["z"]) for punkt in koteliste]
     varianser = [float(var) for var in varliste]
     assert len(koter) == len(varianser), "Mismatch mellem antal koter og varianser"
-    tg = gyldighedstidspunkt(projektnavn)
-    return (punkter, koter, varianser, tg)
+
+    return (punkter, koter, varianser)
 
 
 # ------------------------------------------------------------------------------

--- a/fire/cli/niv/_regn.py
+++ b/fire/cli/niv/_regn.py
@@ -486,18 +486,24 @@ def opdater_arbejdssæt(
     arbejdssæt: Arbejdssæt,
     tg: Timestamp,
 ) -> Arbejdssæt:
-    for j, (punkt, ny_kote, var) in enumerate(zip(punkter, koter, varianser)):
+
+    if len(set(arbejdssæt.system)) > 1:
+        fire.cli.print(
+            "FEJL: Flere forskellige højdereferencesystemer er angivet!",
+            fg="white",
+            bg="red",
+            bold=True,
+        )
+        raise SystemExit()
+
+    kotesystem = arbejdssæt.system[0]
+
+    for (punkt, ny_kote, var) in zip(punkter, koter, varianser):
         if punkt in arbejdssæt.punkt:
             # Hvis punkt findes, sæt indeks til hvor det findes
             i = arbejdssæt.punkt.index(punkt)
-            if i > j:
-                # Gem info i det punkt hvis allerede skrevet
-                arbejdssæt.punkt.append(arbejdssæt.punkt[i])
-                arbejdssæt.ny_sigma.append(arbejdssæt.ny_sigma[i])
-                arbejdssæt.hvornår.append(arbejdssæt.hvornår[i])
-                arbejdssæt.system.append("DVR90")
+
             # Overskriv info i punkt der findes
-            arbejdssæt.punkt[i] = punkt
             arbejdssæt.ny_kote[i] = ny_kote
             arbejdssæt.ny_sigma[i] = sqrt(var)
 
@@ -514,14 +520,13 @@ def opdater_arbejdssæt(
                 continue
             arbejdssæt.opløft[i] = Delta / dt
             arbejdssæt.hvornår[i] = tg
-            arbejdssæt.system[i] = "DVR90"
         else:
             # Tilføj nye punkter
             arbejdssæt.punkt.append(punkt)
             arbejdssæt.ny_sigma.append(sqrt(var))
             arbejdssæt.hvornår.append(tg)
             arbejdssæt.ny_kote.append(ny_kote)
-            arbejdssæt.system.append("DVR90")
+            arbejdssæt.system.append(kotesystem)
 
             # Fyld
             arbejdssæt.fasthold.append("")

--- a/fire/cli/niv/_udtræk_observationer.py
+++ b/fire/cli/niv/_udtræk_observationer.py
@@ -48,6 +48,7 @@ from fire.cli.niv import (
     er_projekt_okay,
     skriv_observationer_geojson,
     skriv_punkter_geojson,
+    KOTESYSTEMER,
 )
 from fire.typologi import (
     adskil_filnavne,
@@ -155,6 +156,12 @@ Er metode ikke angivet, søger programmet blandt begge observationstyper.
     required=False,
     is_flag=True,
 )
+@click.option(
+    "--kotesystem",
+    default="DVR90",
+    type=click.Choice(KOTESYSTEMER.keys()),
+    help="Angiv andet kotesystem end DVR90",
+)
 @fire.cli.default_options()
 def udtræk_observationer(
     projektnavn: str,
@@ -165,6 +172,7 @@ def udtræk_observationer(
     fra: dt.datetime,
     til: dt.datetime,
     alle_obs: bool,
+    kotesystem: str,
     # These `kwargs` can be ignored for now, since they refer to default
     # CLI options that are already in effect by use of call-back functions.
     **kwargs,
@@ -322,6 +330,7 @@ def udtræk_observationer(
     fire.cli.print("Gem observationer og punkter i projekt-regnearket")
     ark_observationer = til_nyt_ark_observationer(observationer)
     ark_punktoversigt = til_nyt_ark_punktoversigt(punkter)
+    ark_punktoversigt["System"] = kotesystem
 
     # Forbered ark-skrivning
     faner = {


### PR DESCRIPTION
Bemærk: Dette PR ligger oven på https://github.com/SDFIdk/FIRE/pull/775 og skal først derfor først merges efter https://github.com/SDFIdk/FIRE/pull/775 er blevet merget! Den første commit der skal tages stilling til er 90f2ffbe31b42692dc207d9bfce4dcf9de80579a. Commits før denne hører til andre pull requests.

Denne PR tilføjer resten af funktionaliteten i niv-modulet, nødvendig for at oprette, vedligeholde og slette Punktsamlinger og Højdetidsserier. Derudover indeholdes nogle generelle forbedringer for at gøre niv-modulet mere ensartet. 

Commitsne er inddelt som følger:
- 90f2ffb, 66acbfb og dbe14e6ecca03480652e8bf8e883e340d6271981 laver generelle forbedringer/ændringer til eksisterende kommandoer. 
- b09e859c06dfef0725a0186ec190023217d41277 giver mulighed for at lukke tidsserier og punktsamlinger
- d2d85088828d3723a762f207d3faec4f3eb55a3e er den vigtigste commit, som sørger for at sagsregnearket, som er centralt for niv-modulet, kan arbejde med andre kotesystemer.
- Endelig gør af59cbcb4a0907d4f5cf09d58ee37af483fa203c så ilæg-nye-koter også knytter de nyberegnede koter til en Højdetidsserie, hvis man ønsker det.