### PR TITLE
Ret stavefejl og andre småting i dokumentation

### DIFF
--- a/docs/datamodel.rst
+++ b/docs/datamodel.rst
@@ -62,7 +62,7 @@ I databasen er hændelserne navngivet "Sagsevents" (og ikke "Sagshændelser", da
 databasen). Ved hver hændelse indsættes der et Sagsevent i databasen.
 Disse kan identificeres ved ID'er. Det er disse ID'er Fikspunktsregisterobjekter
 benytter i attributterne ``sagseventidfra`` og ``sagseventidtil``. Det vil sige
-at hver gang et objekt registeres eller ændres i databasen, er der tilknyttet
+at hver gang et objekt registreres eller ændres i databasen, er der tilknyttet
 metadata til hændelsen. Håndtering af Sager og Sagsevents beskrives yderligere i
 afsnittet :ref:`sager_og_historik`.
 
@@ -318,14 +318,14 @@ kan der kun være en gældende koordinat per punkt. Når en ny Koordinat tilføj
 Punkt afregistreres dens forgænger automatisk.
 
 Ligesom Punktinformationstyperne er SRID'er opdelt efter kategori. Som udgangspunkt
-benyttes EPSG-koder for de systemer der er registeret i EPSG-databasen. De resterende
+benyttes EPSG-koder for de systemer der er registreret i EPSG-databasen. De resterende
 er navngivet efter region eller særligt formål. Se en oversigt over kategorierne i
 tabellen herunder.
 
 ============  =============================================
 **Kategori**  **Beskrivelse**
 ------------  ---------------------------------------------
-EPSG          Koordinatsystemer registeret i EPSG-databasen
+EPSG          Koordinatsystemer registreret i EPSG-databasen
 DK            Danske koordinatsystemer
 GL            Grønlandske koordinatsystemer
 TS            Lokale tidsseriekoordinatsystemer, fx på

--- a/docs/tips/punktsamlinger.rst
+++ b/docs/tips/punktsamlinger.rst
@@ -224,11 +224,11 @@ og med nedslag de steder hvor der er undtagelser.
 ::
 
     fire niv opret-sag MIN_SAG
-    fire niv læs-observationer MIN_SAG --kotesystem jessen
+    fire niv læs-observationer MIN_SAG --kotesystem Jessen
 
 Normalt opbygges Punktoversigten med ``læs-observationer`` ved anvendelse af hvert
 observeret Punkts seneste *DVR90-kote*. Ved anvendelse af det nye flag ``--kotesystem
-jessen`` fortæller man nu programmet, at Punktoversigten skal opbygges ved hjælp af hvert
+Jessen`` fortæller man nu programmet, at Punktoversigten skal opbygges ved hjælp af hvert
 Punkts seneste *jessenkote* i stedet. Denne kote bliver brugt til at vise koteændringer og
 opløft, når man har lavet en beregning.
 
@@ -245,7 +245,7 @@ opløft, når man har lavet en beregning.
   altså med kote og spredning u-udfyldt.
 
 Herefter skal man vælge et fastholdt punkt og dertil en fastholdt kote. *Dette skal være
-et registeret jessenpunkt og referencekote*. Dette gøres ved først at udtrække
+et registreret jessenpunkt og referencekote*. Dette gøres ved først at udtrække
 punktsamlingen, som er blevet opmålt::
 
     fire niv udtræk-punktsamling MIN_SAG --punktsamlingsnavn "PUNKTSAMLING_81xxx"

--- a/docs/workshop/htscase.rst
+++ b/docs/workshop/htscase.rst
@@ -469,7 +469,7 @@ springer vi oprettelsen af nye sager for hver opmåling over.
    beregnet. De fremhævede koter med ring om er de nyberegnede koter som endnu ikke er
    lagt i databasen. De andre punkter er dem, som allerede ligger i databasen.
 
-   .. image:: figures/regn_plot.PNG
+   .. image:: figures/regn_plot.png
 
 Når du er færdig, lukker du sagen::
 

--- a/fire/api/model/observationer.py
+++ b/fire/api/model/observationer.py
@@ -563,7 +563,7 @@ class KoordinatKovarians(Observation):
     samlet koordinatløsning (= tidsseriekoordinaterne).
 
     Kovariansmatricen repræsenterer et estimat for varianser/kovarianser af
-    den samlede koordinatløsning, dvs. af tidsseriekoordinaterne registeret
+    den samlede koordinatløsning, dvs. af tidsseriekoordinaterne registreret
     i FIRE.
 
     Kovarianserne er baseret på geocentriske koordinater.

--- a/fire/cli/niv/_ilæg_nye_punkter.py
+++ b/fire/cli/niv/_ilæg_nye_punkter.py
@@ -76,8 +76,8 @@ def ilæg_nye_punkter(projektnavn: str, sagsbehandler: str, **kwargs) -> None:
     - En angivelse af fikspunktets type
 
     .. image:: ../workshop/figures/firenivilægpunkter.PNG
-    :width: 800
-    :alt: Opret nye punkter, excel-visning
+        :width: 800
+        :alt: Opret nye punkter, excel-visning
 
     De resterende kolonner kan også udfyldes, men den videre proces er ikke
     afhængig af dem. Det man ikke kan udfylde, er "Landsnummer" og "uuid", da det først

--- a/fire/cli/ts/hts.py
+++ b/fire/cli/ts/hts.py
@@ -84,17 +84,17 @@ def hts(objekt: str, parametre: str, fil: click.Path, **kwargs) -> None:
 
         fire ts hts RDIO
 
-    Vis tidsserien "K-63-00909_HTS_81066" med standardparametre::
+    Vis tidsserien G.I.2133_HTS_81066 med standardparametre::
 
-        fire ts hts K-63-00909_HTS_81066
+        fire ts hts G.I.2133_HTS_81066
 
     Vis tidsserie med brugerdefinerede parametre::
 
-        fire ts hts K-63-00909_HTS_81066 --parametre decimalår,kote,sz
+        fire ts hts G.I.2133_HTS_81066 --parametre decimalår,kote,sz
 
     Gem tidsserie med samtlige tilgængelige parametre::
 
-        fire ts hts K-63-00909_HTS_81066 -p alle -f RDIO_HTS_81066.xlsx
+        fire ts hts G.I.2133_HTS_81066 -p alle -f G.I.2133_HTS_81066.xlsx
     """
     _udtræk_tidsserie(objekt, HøjdeTidsserie, HTS_PARAMETRE, parametre, fil)
 
@@ -148,7 +148,7 @@ def plot_hts(tidsserie: str, plottype: str, parametre: str, **kwargs) -> None:
 
     Plot af højdetidsserie for GED3::
 
-        fire ts plot-hts 52-03-00846_HTS_81005
+        fire ts plot-hts GED3_HTS_81005
 
     Resulterer i visning af nedenstående plot.
 
@@ -158,7 +158,7 @@ def plot_hts(tidsserie: str, plottype: str, parametre: str, **kwargs) -> None:
 
     Plot af højdetidsserie for GED2::
 
-        fire ts plot-hts 52-03-00845_HTS_81050 -t fit
+        fire ts plot-hts GED2_HTS_81050 -t fit
 
     Resulterer i visning af nedenstående plot.
 
@@ -168,7 +168,7 @@ def plot_hts(tidsserie: str, plottype: str, parametre: str, **kwargs) -> None:
 
     Plot af højdetidsserie for GED5::
 
-        fire ts plot-hts 52-03-09089_HTS_81068 -t konf
+        fire ts plot-hts GED5_HTS_81068 -t konf
 
     Resulterer i visning af nedenstående plot.
 
@@ -248,7 +248,7 @@ def analyse_hts(
     nedenfor, for detaljer om analysen.
 
     ``OBJEKT`` kan enten være en Punktsamling eller en liste indeholdende én eller flere
-    HøjdeTidsserier.
+    Højdetidsserier.
 
     Hvis ``OBJEKT`` angiver flere Højdetidsserier, skal alle tidsserierne være givet over
     det samme jessenpunkt. Hvis ``OBJEKT`` angiver en Punktsamling analyseres alle


### PR DESCRIPTION
Forskellige småting opdaget under live demo. Herunder:
En enkelt billedfil er gemt som "regn_plot.png", men bliver i dokumentationen refereret som "regn_plot.PNG". Dette går fint når man bygger dokumentationen lokalt, men kan se at billedet ikke bliver vist når det bygges af github.