### PR TITLE
Udvid fire info sag med mere fleksibel søgefunktionalitet

### DIFF
--- a/fire/api/model/sagstyper.py
+++ b/fire/api/model/sagstyper.py
@@ -32,6 +32,27 @@ class EventType(enum.Enum):
     TIDSSERIE_MODIFICERET = 14
     TIDSSERIE_NEDLAGT = 15
 
+# fmt: off
+# Bestem hvilke data som tilknyttes et Sagsevent ud fra EventType
+EVENTTYPER = {
+    EventType.PUNKT_OPRETTET: ("punkter", "geometriobjekter"),
+    EventType.PUNKT_NEDLAGT: ("punkter_slettede", "geometriobjekter_slettede"),
+    EventType.KOORDINAT_BEREGNET: ("koordinater", "beregninger"),
+    EventType.KOORDINAT_NEDLAGT: ("koordinater_slettede","beregninger_slettede"),
+    EventType.OBSERVATION_INDSAT: ("observationer", None),
+    EventType.OBSERVATION_NEDLAGT: ("observationer_slettede", None),
+    EventType.PUNKTINFO_TILFOEJET: ("punktinformationer", None),
+    EventType.PUNKTINFO_FJERNET: ("punktinformationer_slettede", None),
+    EventType.GRAFIK_INDSAT: ("grafikker", None),
+    EventType.GRAFIK_NEDLAGT: ("grafikker_slettede", None),
+    EventType.PUNKTGRUPPE_MODIFICERET: ("punktsamlinger", None),
+    EventType.PUNKTGRUPPE_NEDLAGT: ("punktsamlinger_slettede", None),
+    EventType.TIDSSERIE_MODIFICERET: ("tidsserier", None),
+    EventType.TIDSSERIE_NEDLAGT: ("tidsserier_slettede", None),
+    EventType.KOMMENTAR: (None,),
+}
+# fmt: on
+
 
 class Sag(RegisteringFraObjekt):
     __tablename__ = "sag"
@@ -83,26 +104,6 @@ class Sag(RegisteringFraObjekt):
         if not id:
             id = fire.uuid()
 
-        # fmt: off
-        # Bestem EventType ud fra data tilknyttet sagsevent
-        eventtyper = {
-            EventType.PUNKT_OPRETTET: ("punkter", "geometriobjekter"),
-            EventType.PUNKT_NEDLAGT: ("punkter_slettede", "geometriobjekter_slettede"),
-            EventType.KOORDINAT_BEREGNET: ("koordinater", "beregninger"),
-            EventType.KOORDINAT_NEDLAGT: ("koordinater_slettede","beregninger_slettede"),
-            EventType.OBSERVATION_INDSAT: ("observationer", None),
-            EventType.OBSERVATION_NEDLAGT: ("observationer_slettede", None),
-            EventType.PUNKTINFO_TILFOEJET: ("punktinformationer", None),
-            EventType.PUNKTINFO_FJERNET: ("punktinformationer_slettede", None),
-            EventType.GRAFIK_INDSAT: ("grafikker", None),
-            EventType.GRAFIK_NEDLAGT: ("grafikker_slettede", None),
-            EventType.PUNKTGRUPPE_MODIFICERET: ("punktsamlinger", None),
-            EventType.PUNKTGRUPPE_NEDLAGT: ("punktsamlinger_slettede", None),
-            EventType.TIDSSERIE_MODIFICERET: ("tidsserier", None),
-            EventType.TIDSSERIE_NEDLAGT: ("tidsserier_slettede", None),
-        }
-        # fmt: on
-
         materialer = [SagseventInfoMateriale(materiale=m) for m in materialer]
         htmler = [SagseventInfoHtml(html=html) for html in htmler]
         si = SagseventInfo(
@@ -122,7 +123,7 @@ class Sag(RegisteringFraObjekt):
             )
 
         objekter = list(kwargs.keys())
-        for etype, (obligatorisk, valgfrit) in eventtyper.items():
+        for etype, (obligatorisk, valgfrit) in EVENTTYPER.items():
             if not obligatorisk in objekter:
                 continue
             objekter.remove(obligatorisk)


### PR DESCRIPTION
En lille udvidelse som jeg kom til at lave. Gør så man med fire info sag kan lave fritekstsøgning  på sags-beskrivelsen og filtrere sager på registreringfra-datoen. Hvis søgningen giver flere resultater, så vises en liste af sager (på samme måde som før, hvis man ikke gav noget input), og hvis søgning giver ét resultat vises detaljer om sagen.

Flere resultater:
```
>fire info sag KDI -df 25-04-2024 -dt 25-06-2024

Sagsid     Behandler           Beskrivelse
---------  ------------------  -----------
c326e995:  B363493             KDI: vand sag til tilføj KDI vandsstandsmåler...
48866e21:  b004276             2024_KDI_KLOSTER:...
```
Ét resultat:
```
>fire info sag KDI_KLOSTER
------------------------- SAG -------------------------
  Sagsid        : 48866e21-6409-42db-b7ea-d7b8b8f71826
  Oprettet      : 2024-04-26 12:15:33.228761
  Sagsbehandler : b004276
  Status        : Aktiv  
  Beskrivelse   :        

    2024_KDI_KLOSTER:


[2024-04-26 12:20:32.753646] PUNKT_OPRETTET: Oprettelse af punkt ifm. 2024_KDI_KLOSTER
[2024-04-26 12:20:34.471741] PUNKTINFO_TILFØJET: Oprettelse af punktinfo ifm. 2024_KDI_KLOSTER
```

 Det er WIP som lige skal finpudses lidt, men det virker nogenlunde som jeg synes det skal.