### PR TITLE
Fjern indsættelse af uuid i Punktoversigt ved udtræk af observationer

### DIFF
--- a/fire/io/regneark/__init__.py
+++ b/fire/io/regneark/__init__.py
@@ -127,7 +127,6 @@ def punkt_data(punkt: Punkt) -> dict:
         "Punkt": punkt.ident,
         "Nord": φ,
         "Øst": λ,
-        "uuid": punkt.id,
     }
 
 


### PR DESCRIPTION
Fixes #798
uuid skal svare til id'et for det sagseventid som lagde koten i kolonnen "ny kote"  i databasen. Dette sker først efter man har kørt fire niv ilæg-nye-koter