### PR TITLE
Tilføj mulighed for at filtrere på præcisionsnivellement

### DIFF
--- a/fire/api/niv/udtræk_observationer.py
+++ b/fire/api/niv/udtræk_observationer.py
@@ -174,3 +174,15 @@ def observationer_inden_for_spredning(
         for observation in list(resultatsæt)
         if observation.spredning_afstand <= spredninger[observation.observationstypeid]
     )
+
+
+def filtrer_præcisionsnivellement(
+    observationer: list[Observation], præcisionsnivellement: int
+) -> list[GeometriskKoteforskel]:
+    """Filtrer observationer på præcisionsnivellement hvis de er af typen GeometriskKoteforskel"""
+    return [
+        o
+        for o in observationer
+        if isinstance(o, GeometriskKoteforskel) and
+            o.præcisionsnivellement == præcisionsnivellement
+    ]

--- a/fire/io/regneark/__init__.py
+++ b/fire/io/regneark/__init__.py
@@ -29,9 +29,6 @@ from fire.api.niv.enums import NivMetode
 from fire.srid import SRID
 from fire.io.regneark import arkdef
 import fire.io.dataframe as frame
-from fire.api.model.geometry import (
-    normaliser_lokationskoordinat,
-)
 
 
 # Annoteringstyper
@@ -121,8 +118,7 @@ PUNKTOVERSIGT_KONSTANTE_FELTER = {
 
 
 def punkt_data(punkt: Punkt) -> dict:
-    WGS84_lonlat = punkt.geometri.koordinater
-    λ, φ = normaliser_lokationskoordinat(*WGS84_lonlat)
+    λ, φ = punkt.geometri.koordinater
     return {
         "Punkt": punkt.ident,
         "Nord": φ,

--- a/test/api/niv/test_udtræk_observationer.py
+++ b/test/api/niv/test_udtræk_observationer.py
@@ -29,6 +29,7 @@ from fire.api.niv.udtræk_observationer import (
     søgefunktioner_med_valgte_metoder,
     brug_alle_på_alle,
     observationer_inden_for_spredning,
+    filtrer_præcisionsnivellement,
     timestamp,
     punkter_til_geojson,
 )
@@ -175,6 +176,35 @@ def test_observationer_inden_for_spredning():
     result = set(observationer_inden_for_spredning(tks, spredning))
     expected = tks_indenfor
     assert result == expected, f"Forventede, at {result!r} var {expected!r}."
+
+
+@pytest.mark.parametrize("præc, forventet_antal", [(0, 1), (1, 2), (2, 3), (3, 4)])
+def test_filtrer_præcisionsnivellement(præc, forventet_antal):
+
+    tks = [TK() for _ in range(3)]
+
+    gks = [
+        GK(præcisionsnivellement=0),
+        GK(præcisionsnivellement=1),
+        GK(præcisionsnivellement=1),
+        GK(præcisionsnivellement=2),
+        GK(præcisionsnivellement=2),
+        GK(præcisionsnivellement=2),
+        GK(præcisionsnivellement=3),
+        GK(præcisionsnivellement=3),
+        GK(præcisionsnivellement=3),
+        GK(præcisionsnivellement=3),
+    ]
+
+    alle = tks + gks
+
+    filtrerede = filtrer_præcisionsnivellement(tks, præc)
+
+    assert len(filtrerede) == 0
+
+    filtrerede = filtrer_præcisionsnivellement(alle, præc)
+
+    assert len(filtrerede) == forventet_antal
 
 
 @pytest.mark.freeze_time("2021-11-01T21:21:00")


### PR DESCRIPTION
Fixes #802

Føjer parameteren `--præc` / `-P` til `fire niv udtræk-observationer` så det er muligt at filtrere observationer på de tre præcisionsnivellementer.