### PR TITLE
Undlad oprettelse af landsnumre for punkter udenfor DK

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,6 +24,7 @@ dependencies:
   - python=3.11.*
   - rich
   - scipy
+  - shapely=1.8.*
   - sphinx-click
   - sphinx
   - sphinx_rtd_theme

--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - python=3.11.*
   - rich=13.*
   - scipy=1.14.*
+  - shapely=1.8.*
   - sqlalchemy=1.4.*
   - xmltodict=0.14.*


### PR DESCRIPTION
Ved oprettelse af nye punkter med `fire niv ilæg-revision` resulterer oprettelse af punkter udenfor Danmark i en fejl før denne ændring. Fejlen opstår fordi det forventes at punktet er indeholdt i et opmålingsdristrikt. Når punktet ikke er det går det galt. Derfor frasorteres punkter udenfor Danmark nu før der tildeles landsnumre.

Som nævnt i en kommentar i koden er det et rudimentært tjek, der på sigt kan forfines. For nu bør det løse problemet i lang de fleste tilfælde.

`shapely` er eksplicit tilføjet mamba-miljøet. Pakken er i forvejen tilgængelig, da den benyttes af andre pakker og er derfor ikke en ny afhængighed som sådan.

Herunder ses de to polygoner der bruges til at afgøre om et punkt befinder sig indenfor Danmark eller ej. Med grønt er vist opmålingsdistrikterne og gråt giver vist sig selv:
![billede](https://github.com/user-attachments/assets/c2c88dbd-c0e8-4569-9eb9-56ebba1fe633)
