### PR TITLE
Anvend korrekt database i funktionen udled_jessenpunkt_fra_punktoversigt

### DIFF
--- a/fire/cli/niv/__init__.py
+++ b/fire/cli/niv/__init__.py
@@ -685,7 +685,7 @@ def udled_jessenpunkt_fra_punktoversigt(
     jessenpunkt_kote = fastholdte_koter.iloc[0]
 
     try:
-        jessenpunkt = firedb.hent_punkt(jessenpunkt_ident)
+        jessenpunkt = fire.cli.firedb.hent_punkt(jessenpunkt_ident)
     except NoResultFound:
         fire.cli.print(
             f"FEJL: Kunne ikke finde Jessenpunktet {jessenpunkt_ident} i databasen!",


### PR DESCRIPTION
Der blev anvendt `firedb`, hvilket svarer til default-databaseforbindelsen. Dette er rettet til `fire.cli.firedb`, således at der nu anvendes forbindelsen valgt med `--db` parameteren

Fixes #816