### PR TITLE
`udtræk-observationer` : Frasorter ikke punkter uden DVR90 kote

### DIFF
--- a/src/fire/cli/niv/_udtræk_observationer.py
+++ b/src/fire/cli/niv/_udtræk_observationer.py
@@ -275,12 +275,10 @@ def udtræk_observationer(
             fire.cli.print("Søg med punkterne som opstillingspunkt", fg="yellow")
             objekter = punkter
             # Forbereder søgefunktion med argumenter fastsat.
-            DVR90 = db.hent_srid(SRID.DVR90)
             funktion = db.hent_observationer_fra_opstillingspunkt
             fastholdte_argumenter = dict(
                 tid_fra=fra,
                 tid_til=til,
-                srid=DVR90,
                 kun_aktive=True,
                 sigtepunkter=punkter,
             )


### PR DESCRIPTION
Fixer del 2.i af #781

Gør så observationer til punkter uden en DVR90 kote ikke frasorteres. Ellers kan man ikke fremsøge observationer til fx midlertidige hjælpepunkter som aldrig har fået en DVR90 kote.  Disse observationer er nødvendige for at nivellement linjerne hænger sammen.